### PR TITLE
Apply updated and deleted tuples from writeset

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2273,7 +2273,7 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 
 	/* 
 	 * Put into the write set of remotexact. 
-	 * TODO: speculative inserts are ignored. Need a mechanism to keep
+	 * TODO (ctring): speculative inserts are ignored. Need a mechanism to keep
 	 * 		 track of whether they are finished or canceled.
 	 */
 	if (!(options & HEAP_INSERT_SPECULATIVE))
@@ -2994,6 +2994,23 @@ l1:
 	 */
 	old_key_tuple = ExtractReplicaIdentity(relation, &tp, true, &old_key_copied);
 
+	if (RelationIsUsedInRemoteXact(relation))
+	{
+		/*
+		 * Put the deleted tuple into the write set of remotexact.
+		 */
+		CollectDelete(relation, old_key_tuple);
+
+		/*
+		 * Free this early so that it is not WAL-logged.
+		 */
+		if (old_key_tuple != NULL && old_key_copied)
+		{
+			heap_freetuple(old_key_tuple);
+			old_key_tuple = NULL;
+		}
+	}
+
 	/*
 	 * If this is the first possibly-multixact-able operation in the current
 	 * transaction, set my per-backend OldestMemberMXactId setting. We can be
@@ -3149,11 +3166,6 @@ l1:
 	 */
 	if (have_tuple_lock)
 		UnlockTupleTuplock(relation, &(tp.t_self), LockTupleExclusive);
-
-	/*
-	 * Put the old tuple into the write set of remotexact.
-	 */
-	CollectDelete(relation, old_key_tuple);
 
 	pgstat_count_heap_delete(relation);
 
@@ -3969,6 +3981,23 @@ l2:
 										   id_has_external,
 										   &old_key_copied);
 
+	if (RelationIsUsedInRemoteXact(relation))
+	{
+		/*
+		 * Put the updated tuple into the write set of remotexact
+		 */
+		CollectUpdate(relation, old_key_tuple, heaptup);
+
+		/*
+		 * Free this early so that it is not WAL-logged.
+		 */
+		if (old_key_tuple != NULL && old_key_copied)
+		{
+			heap_freetuple(old_key_tuple);
+			old_key_tuple = NULL;
+		}
+	}
+
 	/* NO EREPORT(ERROR) from here till changes are logged */
 	START_CRIT_SECTION();
 
@@ -4096,11 +4125,6 @@ l2:
 	 */
 	if (have_tuple_lock)
 		UnlockTupleTuplock(relation, &(oldtup.t_self), *lockmode);
-
-	/*
-	 * Put into the write set of remotexact
-	 */
-	CollectUpdate(relation, old_key_tuple, heaptup);
 
 	pgstat_count_heap_update(relation, use_hot_update);
 
@@ -8454,7 +8478,7 @@ ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
 
 	*copy = false;
 
-	if (!RelationIsLogicallyLogged(relation))
+	if (!RelationIsLogicallyLogged(relation) && !RelationIsUsedInRemoteXact(relation))
 		return NULL;
 
 	if (replident == REPLICA_IDENTITY_NOTHING)

--- a/src/backend/access/rmgrdesc/xlogdesc.c
+++ b/src/backend/access/rmgrdesc/xlogdesc.c
@@ -29,6 +29,7 @@ const struct config_enum_entry wal_level_options[] = {
 	{"replica", WAL_LEVEL_REPLICA, false},
 	{"archive", WAL_LEVEL_REPLICA, true},	/* deprecated */
 	{"hot_standby", WAL_LEVEL_REPLICA, true},	/* deprecated */
+	{"remote_xact", WAL_LEVEL_REMOTE_XACT, false},
 	{"logical", WAL_LEVEL_LOGICAL, false},
 	{NULL, 0, false}
 };

--- a/src/bin/pg_controldata/pg_controldata.c
+++ b/src/bin/pg_controldata/pg_controldata.c
@@ -78,6 +78,8 @@ wal_level_str(WalLevel wal_level)
 			return "minimal";
 		case WAL_LEVEL_REPLICA:
 			return "replica";
+		case WAL_LEVEL_REMOTE_XACT:
+			return "remote_xact";
 		case WAL_LEVEL_LOGICAL:
 			return "logical";
 	}

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -170,6 +170,7 @@ typedef enum WalLevel
 {
 	WAL_LEVEL_MINIMAL = 0,
 	WAL_LEVEL_REPLICA,
+	WAL_LEVEL_REMOTE_XACT,
 	WAL_LEVEL_LOGICAL
 } WalLevel;
 
@@ -221,6 +222,9 @@ extern PGDLLIMPORT int wal_level;
 
 /* Do we need to WAL-log information required only for logical replication? */
 #define XLogLogicalInfoActive() (wal_level >= WAL_LEVEL_LOGICAL)
+
+/* Do we need to WAL-log information required only for Hot Standby and remote xact? */
+#define XLogRemoteXactInfoActive() (wal_level >= WAL_LEVEL_REMOTE_XACT)
 
 #ifdef WAL_DEBUG
 extern bool XLOG_DEBUG;

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -667,6 +667,20 @@ typedef struct ViewOptions
 	 (relation)->rd_rel->relkind != RELKIND_FOREIGN_TABLE &&	\
 	 !IsCatalogRelation(relation))
 
+/*
+ * RelationIsUsedInRemoteXact
+ * 		True if we need to collect the changes to this relation in the write set
+ * 		of a transaction.
+ * 
+ * This is similar to RelationIsLogicallyLogged but we only want to generate the
+ * extra information for logical replication without actually WAL-logging it.
+ */
+#define RelationIsUsedInRemoteXact(relation) \
+	(XLogRemoteXactInfoActive() && \
+	 RelationNeedsWAL(relation) && \
+	 (relation)->rd_rel->relkind != RELKIND_FOREIGN_TABLE && \
+	 !IsCatalogRelation(relation))
+
 /* routines in utils/cache/relcache.c */
 extern void RelationIncrementReferenceCount(Relation rel);
 extern void RelationDecrementReferenceCount(Relation rel);


### PR DESCRIPTION
 New wal_level remote_xact to generate logical log info without wal-logging it.