### PR TITLE
Fix bug in csn code that breaks 2pc

### DIFF
--- a/src/backend/access/transam/csn_snapshot.c
+++ b/src/backend/access/transam/csn_snapshot.c
@@ -287,7 +287,7 @@ XidInvisibleInCSNSnapshot(TransactionId xid, Snapshot snapshot)
  */
 void
 CSNSnapshotAbort(PGPROC *proc, TransactionId xid,
-					int nsubxids, TransactionId *subxids)
+				 int nsubxids, TransactionId *subxids)
 {
 	if (!get_csnlog_status())
 		return;
@@ -332,8 +332,7 @@ CSNSnapshotPrecommit(PGPROC *proc, TransactionId xid,
 	if (in_progress)
 	{
 		Assert(XidCSNIsInProgress(oldassignedXidCsn));
-		CSNLogSetCSN(xid, nsubxids,
-						   subxids, InDoubtXidCSN, true);
+		CSNLogSetCSN(xid, nsubxids, subxids, InDoubtXidCSN, true);
 	}
 	else
 	{
@@ -356,7 +355,7 @@ CSNSnapshotPrecommit(PGPROC *proc, TransactionId xid,
  */
 void
 CSNSnapshotCommit(PGPROC *proc, TransactionId xid,
-					int nsubxids, TransactionId *subxids)
+				  int nsubxids, TransactionId *subxids)
 {
 	volatile XidCSN assigned_xid_csn;
 
@@ -373,8 +372,7 @@ CSNSnapshotCommit(PGPROC *proc, TransactionId xid,
 	/* Finally write resulting XidCSN in SLRU */
 	assigned_xid_csn = pg_atomic_read_u64(&proc->assignedXidCsn);
 	Assert(XidCSNIsNormal(assigned_xid_csn));
-	CSNLogSetCSN(xid, nsubxids,
-						   subxids, assigned_xid_csn, true);
+	CSNLogSetCSN(xid, nsubxids, subxids, assigned_xid_csn, true);
 
 	/* Reset for next transaction */
 	pg_atomic_write_u64(&proc->assignedXidCsn, InProgressXidCSN);

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1556,8 +1556,7 @@ FinishPreparedTransaction(const char *gid, bool isCommit)
 	 * going to become visible. Details in comments to this functions.
 	 */
 	if (!isCommit)
-		CSNSnapshotAbort(proc, xid, hdr->nsubxacts, children);
-
+		CSNSnapshotAbort(MyProc, xid, hdr->nsubxacts, children);
 
 	ProcArrayRemove(proc, latestXid);
 
@@ -1569,12 +1568,11 @@ FinishPreparedTransaction(const char *gid, bool isCommit)
 	 */
 	if (isCommit)
 	{
-		CSNSnapshotCommit(proc, xid, hdr->nsubxacts, children);
+		CSNSnapshotCommit(MyProc, xid, hdr->nsubxacts, children);
 	}
 	else
 	{
-		Assert(XidCSNIsInProgress(
-				   pg_atomic_read_u64(&proc->assignedXidCsn)));
+		Assert(XidCSNIsInProgress(pg_atomic_read_u64(&MyProc->assignedXidCsn)));
 	}
 
 	/*


### PR DESCRIPTION
The CSN code in 2pc use `proc` as the argument for its functions. However, this proc is the proc that previously prepared the transaction, not the current one. 