### PR TITLE
Properly execute remotexact

### DIFF
--- a/src/backend/storage/lmgr/predicate.c
+++ b/src/backend/storage/lmgr/predicate.c
@@ -2557,8 +2557,10 @@ PredicateLockAcquire(const PREDICATELOCKTARGETTAG *targettag)
 	}
 
 	/*
-	 * Collect the read set of the current transaction. TODO: Make use of the
-	 * promoting mechanism above to reduce the size of the read set.
+	 * Collect the read set of the current transaction.
+	 *
+	 * TODO (ctring): Make use of the promoting mechanism above to reduce the
+	 * size of the read set.
 	 */
 	switch (GET_PREDICATELOCKTARGETTAG_TYPE(*targettag))
 	{

--- a/src/include/access/remotexact.h
+++ b/src/include/access/remotexact.h
@@ -47,8 +47,7 @@ typedef struct
 	void		(*collect_insert) (Relation relation, HeapTuple newtuple);
 	void		(*collect_update) (Relation relation, HeapTuple oldtuple, HeapTuple newtuple);
 	void		(*collect_delete) (Relation relation, HeapTuple oldtuple);
-	void		(*clear_rwset) (void);
-	void		(*send_rwset_and_wait) (void);
+	void		(*execute_remote_xact) (void);
 } RemoteXactHook;
 
 extern void SetRemoteXactHook(const RemoteXactHook *hook);
@@ -62,8 +61,6 @@ extern void CollectUpdate(Relation relation, HeapTuple oldtuple, HeapTuple newtu
 extern void CollectDelete(Relation relation, HeapTuple oldtuple);
 
 extern bool is_surrogate;
-extern void SendRwsetAndWait(void);
-
-extern void AtEOXact_RemoteXact(void);
+extern void PreCommit_ExecuteRemoteXact(void);
 
 #endif							/* REMOTEXACT_H */


### PR DESCRIPTION
+ Rename `SendRwsetAndWait` to `PreCommit_ExecuteRemoteXact` and call it at a better place.
+ Remove `AtEOXact_RemoteXact`. Instead, register the cleanup function from the remotexact plugin as a callback that is called on transaction commit/abort.