### PR TITLE
Read slru page at lsn.

### DIFF
--- a/src/backend/access/transam/clog.c
+++ b/src/backend/access/transam/clog.c
@@ -358,9 +358,10 @@ TransactionIdSetPageStatusInternal(TransactionId xid, int nsubxids,
 	 * write-busy, since we don't care if the update reaches disk sooner than
 	 * we think.
 	 */
-	slotno = SimpleLruReadPage(XactCtl, pageno, XLogRecPtrIsInvalid(lsn), xid);
+	slotno = SimpleLruReadPage(XactCtl, pageno, XLogRecPtrIsInvalid(lsn),
+								xid, InvalidXLogRecPtr);
 
-	/*
+        /*
 	 * Set the main transaction id, if any.
 	 *
 	 * If we update more than one xid on this page while it is being written
@@ -649,7 +650,8 @@ TransactionIdGetStatus(TransactionId xid, XLogRecPtr *lsn)
 
 	/* lock is acquired by SimpleLruReadPage_ReadOnly */
 
-	slotno = SimpleLruReadPage_ReadOnly(XactCtl, pageno, xid);
+	slotno =
+		SimpleLruReadPage_ReadOnly(XactCtl, pageno, xid, InvalidXLogRecPtr);
 	byteptr = XactCtl->shared->page_buffer[slotno] + byteno;
 
 	status = (*byteptr >> bshift) & CLOG_XACT_BITMASK;
@@ -798,7 +800,8 @@ TrimCLOG(void)
 		int			slotno;
 		char	   *byteptr;
 
-		slotno = SimpleLruReadPage(XactCtl, pageno, false, xid);
+		slotno = SimpleLruReadPage(XactCtl, pageno, false, xid,
+									InvalidXLogRecPtr);
 		byteptr = XactCtl->shared->page_buffer[slotno] + byteno;
 
 		/* Zero so-far-unused positions in the current byte */

--- a/src/backend/access/transam/commit_ts.c
+++ b/src/backend/access/transam/commit_ts.c
@@ -222,9 +222,10 @@ SetXidCommitTsInPage(TransactionId xid, int nsubxids,
 
 	LWLockAcquire(CommitTsSLRULock, LW_EXCLUSIVE);
 
-	slotno = SimpleLruReadPage(CommitTsCtl, pageno, true, xid);
+	slotno = SimpleLruReadPage(CommitTsCtl, pageno, true, xid,
+								InvalidXLogRecPtr);
 
-	TransactionIdSetCommitTs(xid, ts, nodeid, slotno);
+        TransactionIdSetCommitTs(xid, ts, nodeid, slotno);
 	for (i = 0; i < nsubxids; i++)
 		TransactionIdSetCommitTs(subxids[i], ts, nodeid, slotno);
 
@@ -327,7 +328,8 @@ TransactionIdGetCommitTsData(TransactionId xid, TimestampTz *ts,
 	}
 
 	/* lock is acquired by SimpleLruReadPage_ReadOnly */
-	slotno = SimpleLruReadPage_ReadOnly(CommitTsCtl, pageno, xid);
+	slotno = SimpleLruReadPage_ReadOnly(CommitTsCtl, pageno, xid,
+										InvalidXLogRecPtr);
 	memcpy(&entry,
 		   CommitTsCtl->shared->page_buffer[slotno] +
 		   SizeOfCommitTimestampEntry * entryno,

--- a/src/backend/access/transam/csn_log.c
+++ b/src/backend/access/transam/csn_log.c
@@ -166,9 +166,10 @@ CSNLogSetPageStatus(TransactionId xid, int nsubxids,
 
 	LWLockAcquire(CSNLogControlLock, LW_EXCLUSIVE);
 
-	slotno = SimpleLruReadPage(CsnlogCtl, pageno, true, xid);
+	slotno =
+		SimpleLruReadPage(CsnlogCtl, pageno, true, xid, InvalidXLogRecPtr);
 
-	/* Subtransactions first, if needed ... */
+    /* Subtransactions first, if needed ... */
 	for (i = 0; i < nsubxids; i++)
 	{
         Assert(CsnlogCtl->shared->page_number[slotno] ==
@@ -215,11 +216,12 @@ CSNLogGetCSNByXid(TransactionId xid)
 	int			pageno = TransactionIdToPage(xid, current_region);
 	int			entryno = TransactionIdToPgIndex(xid);
 	int			slotno;
+	XLogRecPtr  min_lsn = InvalidXLogRecPtr;
 	XidCSN *ptr;
 	XidCSN	xid_csn;
 
 	/* lock is acquired by SimpleLruReadPage_ReadOnly */
-	slotno = SimpleLruReadPage_ReadOnly(CsnlogCtl, pageno, xid);
+	slotno = SimpleLruReadPage_ReadOnly(CsnlogCtl, pageno, xid, min_lsn);
 
 	ptr = (XidCSN *) (CsnlogCtl->shared->page_buffer[slotno] + entryno * sizeof(XidCSN));
 	xid_csn = *ptr;

--- a/src/backend/access/transam/multixact.c
+++ b/src/backend/access/transam/multixact.c
@@ -881,7 +881,8 @@ RecordNewMultiXact(MultiXactId multi, MultiXactOffset offset,
 	 * enough that a MultiXactId is really involved.  Perhaps someday we'll
 	 * take the trouble to generalize the slru.c error reporting code.
 	 */
-	slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true, multi);
+	slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true, multi,
+								InvalidXLogRecPtr);
 	offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
 	offptr += entryno;
 
@@ -914,7 +915,8 @@ RecordNewMultiXact(MultiXactId multi, MultiXactOffset offset,
 
 		if (pageno != prev_pageno)
 		{
-			slotno = SimpleLruReadPage(MultiXactMemberCtl, pageno, true, multi);
+			slotno = SimpleLruReadPage(MultiXactMemberCtl, pageno, true,
+										multi, InvalidXLogRecPtr);
 			prev_pageno = pageno;
 		}
 
@@ -1345,7 +1347,8 @@ retry:
 	pageno = MultiXactIdToOffsetPage(multi);
 	entryno = MultiXactIdToOffsetEntry(multi);
 
-	slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true, multi);
+	slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true, multi,
+								InvalidXLogRecPtr);
 	offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
 	offptr += entryno;
 	offset = *offptr;
@@ -1377,9 +1380,10 @@ retry:
 		entryno = MultiXactIdToOffsetEntry(tmpMXact);
 
 		if (pageno != prev_pageno)
-			slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true, tmpMXact);
+			slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true,
+										tmpMXact, InvalidXLogRecPtr);
 
-		offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
+        offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
 		offptr += entryno;
 		nextMXOffset = *offptr;
 
@@ -1417,7 +1421,8 @@ retry:
 
 		if (pageno != prev_pageno)
 		{
-			slotno = SimpleLruReadPage(MultiXactMemberCtl, pageno, true, multi);
+			slotno = SimpleLruReadPage(MultiXactMemberCtl, pageno, true,
+										multi, InvalidXLogRecPtr);
 			prev_pageno = pageno;
 		}
 
@@ -2068,7 +2073,8 @@ TrimMultiXact(void)
 		int			slotno;
 		MultiXactOffset *offptr;
 
-		slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true, nextMXact);
+		slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true,
+									nextMXact, InvalidXLogRecPtr);
 		offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
 		offptr += entryno;
 
@@ -2100,8 +2106,9 @@ TrimMultiXact(void)
 		int			memberoff;
 
 		memberoff = MXOffsetToMemberOffset(offset);
-		slotno = SimpleLruReadPage(MultiXactMemberCtl, pageno, true, offset);
-		xidptr = (TransactionId *)
+		slotno = SimpleLruReadPage(MultiXactMemberCtl, pageno, true,
+									offset, InvalidXLogRecPtr);
+        xidptr = (TransactionId *)
 			(MultiXactMemberCtl->shared->page_buffer[slotno] + memberoff);
 
 		MemSet(xidptr, 0, BLCKSZ - memberoff);
@@ -2754,8 +2761,9 @@ find_multixact_start(MultiXactId multi, MultiXactOffset *result)
 		return false;
 
 	/* lock is acquired by SimpleLruReadPage_ReadOnly */
-	slotno = SimpleLruReadPage_ReadOnly(MultiXactOffsetCtl, pageno, multi);
-	offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
+	slotno = SimpleLruReadPage_ReadOnly(MultiXactOffsetCtl, pageno, multi,
+										InvalidXLogRecPtr);
+        offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
 	offptr += entryno;
 	offset = *offptr;
 	LWLockRelease(MultiXactOffsetSLRULock);

--- a/src/backend/access/transam/slru.c
+++ b/src/backend/access/transam/slru.c
@@ -138,7 +138,7 @@ static void SimpleLruZeroLSNs(SlruCtl ctl, int slotno);
 static void SimpleLruWaitIO(SlruCtl ctl, int slotno);
 static bool SimpleLruDoesPhysicalPageExistDefault(SlruCtl ctl, int pageno);
 static void SlruInternalWritePage(SlruCtl ctl, int slotno, SlruWriteAll fdata);
-static bool SlruPhysicalReadPage(SlruCtl ctl, int pageno, int slotno);
+static bool SlruPhysicalReadPage(SlruCtl ctl, int pageno, int slotno, XLogRecPtr min_lsn);
 static bool SlruPhysicalReadPageDefault(SlruCtl ctl, int pageno, int slotno);
 static bool SlruPhysicalWritePage(SlruCtl ctl, int pageno, int slotno,
 								  SlruWriteAll fdata);
@@ -170,7 +170,8 @@ SimpleLruShmemSize(int nslots, int nlsns)
 	sz += MAXALIGN(nslots * sizeof(bool));	/* page_dirty[] */
 	sz += MAXALIGN(nslots * sizeof(int));	/* page_number[] */
 	sz += MAXALIGN(nslots * sizeof(int));	/* page_lru_count[] */
-	sz += MAXALIGN(nslots * sizeof(LWLockPadded));	/* buffer_locks[] */
+	sz += MAXALIGN(nslots * sizeof(XLogRecPtr));	/* page_lsn[] */
+	sz += MAXALIGN(nslots * sizeof(LWLockPadded)); /* buffer_locks[] */
 
 	if (nlsns > 0)
 		sz += MAXALIGN(nslots * nlsns * sizeof(XLogRecPtr));	/* group_lsn[] */
@@ -235,6 +236,8 @@ SimpleLruInit(SlruCtl ctl, const char *name, int nslots, int nlsns,
 		offset += MAXALIGN(nslots * sizeof(int));
 		shared->page_lru_count = (int *) (ptr + offset);
 		offset += MAXALIGN(nslots * sizeof(int));
+		shared->page_lsn = (XLogRecPtr *) (ptr + offset);
+		offset += MAXALIGN(nslots * sizeof(XLogRecPtr));
 
 		/* Initialize LWLocks */
 		shared->buffer_locks = (LWLockPadded *) (ptr + offset);
@@ -256,6 +259,7 @@ SimpleLruInit(SlruCtl ctl, const char *name, int nslots, int nlsns,
 			shared->page_status[slotno] = SLRU_PAGE_EMPTY;
 			shared->page_dirty[slotno] = false;
 			shared->page_lru_count[slotno] = 0;
+			shared->page_lsn[slotno] = InvalidXLogRecPtr;
 			ptr += BLCKSZ;
 		}
 
@@ -300,6 +304,7 @@ SimpleLruZeroPage(SlruCtl ctl, int pageno)
 	shared->page_status[slotno] = SLRU_PAGE_VALID;
 	shared->page_dirty[slotno] = true;
 	SlruRecentlyUsed(shared, slotno);
+	shared->page_lsn[slotno] = InvalidXLogRecPtr;
 
 	/* Set the buffer to zeroes */
 	MemSet(shared->page_buffer[slotno], 0, BLCKSZ);
@@ -399,7 +404,7 @@ SimpleLruWaitIO(SlruCtl ctl, int slotno)
  */
 int
 SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
-				  TransactionId xid)
+				  XLogRecPtr min_lsn, TransactionId xid)
 {
 	SlruShared	shared = ctl->shared;
 
@@ -414,7 +419,9 @@ SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
 
 		/* Did we find the page in memory? */
 		if (shared->page_number[slotno] == pageno &&
-			shared->page_status[slotno] != SLRU_PAGE_EMPTY)
+			shared->page_status[slotno] != SLRU_PAGE_EMPTY &&
+			(min_lsn == InvalidXLogRecPtr ||
+			min_lsn <= shared->page_lsn[slotno]))
 		{
 			/*
 			 * If page is still being read in, we must wait for I/O.  Likewise
@@ -431,6 +438,12 @@ SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
 			/* Otherwise, it's ready to use */
 			SlruRecentlyUsed(shared, slotno);
 
+			if (min_lsn != InvalidXLogRecPtr ||
+			min_lsn <= shared->page_lsn[slotno]) {
+				// We have not found the page at the required lsn.
+				continue;
+			}
+
 			/* update the stats counter of pages found in the SLRU */
 			pgstat_count_slru_page_hit(shared->slru_stats_idx);
 
@@ -446,6 +459,7 @@ SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
 		shared->page_number[slotno] = pageno;
 		shared->page_status[slotno] = SLRU_PAGE_READ_IN_PROGRESS;
 		shared->page_dirty[slotno] = false;
+		shared->page_lsn[slotno] = min_lsn;
 
 		/* Acquire per-buffer lock (cannot deadlock, see notes at top) */
 		LWLockAcquire(&shared->buffer_locks[slotno].lock, LW_EXCLUSIVE);
@@ -454,7 +468,7 @@ SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
 		LWLockRelease(shared->ControlLock);
 
 		/* Do the read */
-		ok = SlruPhysicalReadPage(ctl, pageno, slotno);
+		ok = SlruPhysicalReadPage(ctl, pageno, slotno, min_lsn);
 
 		/* Set the LSNs for this newly read-in page to zero */
 		SimpleLruZeroLSNs(ctl, slotno);
@@ -498,7 +512,8 @@ SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
  * It is unspecified whether the lock will be shared or exclusive.
  */
 int
-SimpleLruReadPage_ReadOnly(SlruCtl ctl, int pageno, TransactionId xid)
+SimpleLruReadPage_ReadOnly(SlruCtl ctl, int pageno, XLogRecPtr min_lsn,
+						   TransactionId xid)
 {
 	SlruShared	shared = ctl->shared;
 	int			slotno;
@@ -506,12 +521,17 @@ SimpleLruReadPage_ReadOnly(SlruCtl ctl, int pageno, TransactionId xid)
 	/* Try to find the page while holding only shared lock */
 	LWLockAcquire(shared->ControlLock, LW_SHARED);
 
-	/* See if page is already in a buffer */
+	/* See if page is already in a buffer. If the request contains a valid
+	 * min_lsn, then ensure that the page we pick has lsn set to at least
+	 * min_lsn.
+	 */
 	for (slotno = 0; slotno < shared->num_slots; slotno++)
 	{
 		if (shared->page_number[slotno] == pageno &&
 			shared->page_status[slotno] != SLRU_PAGE_EMPTY &&
-			shared->page_status[slotno] != SLRU_PAGE_READ_IN_PROGRESS)
+			shared->page_status[slotno] != SLRU_PAGE_READ_IN_PROGRESS &&
+			(min_lsn == InvalidXLogRecPtr ||
+			min_lsn <= shared->page_lsn[slotno]))
 		{
 			/* See comments for SlruRecentlyUsed macro */
 			SlruRecentlyUsed(shared, slotno);
@@ -527,7 +547,7 @@ SimpleLruReadPage_ReadOnly(SlruCtl ctl, int pageno, TransactionId xid)
 	LWLockRelease(shared->ControlLock);
 	LWLockAcquire(shared->ControlLock, LW_EXCLUSIVE);
 
-	return SimpleLruReadPage(ctl, pageno, true, xid);
+	return SimpleLruReadPage(ctl, pageno, true, xid, min_lsn);
 }
 
 /*
@@ -557,11 +577,13 @@ SlruInternalWritePage(SlruCtl ctl, int slotno, SlruWriteAll fdata)
 
 	/*
 	 * Do nothing if page is not dirty, or if buffer no longer contains the
-	 * same page we were called for.
+	 * same page we were called for. Also, if the buffer has a page_lsn set,
+	 * then it "likely" belongs to another region, we should do nothing. 
 	 */
 	if (!shared->page_dirty[slotno] ||
 		shared->page_status[slotno] != SLRU_PAGE_VALID ||
-		shared->page_number[slotno] != pageno)
+		shared->page_number[slotno] != pageno ||
+		shared->page_lsn[slotno] != InvalidXLogRecPtr)
 		return;
 
 	/*
@@ -709,7 +731,7 @@ SimpleLruDoesPhysicalPageExistDefault(SlruCtl ctl, int pageno)
  * to the default read function.
  */
 static bool
-SlruPhysicalReadPage(SlruCtl ctl, int pageno, int slotno)
+SlruPhysicalReadPage(SlruCtl ctl, int pageno, int slotno, XLogRecPtr min_lsn)
 {
 	if (slru_kind_check_hook && (*slru_kind_check_hook)(ctl))
 	{
@@ -721,8 +743,8 @@ SlruPhysicalReadPage(SlruCtl ctl, int pageno, int slotno)
 		Assert(slru_read_page_hook);
 
 		pgstat_report_wait_start(WAIT_EVENT_SLRU_READ);
-		if (!(*slru_read_page_hook)(ctl, segno, blkno, shared->page_buffer[slotno]))
-		{
+        if (!(*slru_read_page_hook)(ctl, segno, blkno, min_lsn,
+                					shared->page_buffer[slotno])) {
 			pgstat_report_wait_end();
 			slru_errcause = SLRU_READ_FAILED;
 			slru_errno = EIO;

--- a/src/backend/access/transam/slru.c
+++ b/src/backend/access/transam/slru.c
@@ -143,7 +143,7 @@ static bool SlruPhysicalReadPageDefault(SlruCtl ctl, int pageno, int slotno);
 static bool SlruPhysicalWritePage(SlruCtl ctl, int pageno, int slotno,
 								  SlruWriteAll fdata);
 static void SlruReportIOError(SlruCtl ctl, int pageno, TransactionId xid);
-static int	SlruSelectLRUPage(SlruCtl ctl, int pageno);
+static int	SlruSelectLRUPage(SlruCtl ctl, int pageno, XLogRecPtr min_lsn);
 
 static bool SlruScanDirCbDeleteCutoff(SlruCtl ctl, char *filename,
 									  int segpage, void *data);
@@ -293,7 +293,7 @@ SimpleLruZeroPage(SlruCtl ctl, int pageno)
 	int			slotno;
 
 	/* Find a suitable buffer slot for the page */
-	slotno = SlruSelectLRUPage(ctl, pageno);
+	slotno = SlruSelectLRUPage(ctl, pageno, InvalidXLogRecPtr);
 	Assert(shared->page_status[slotno] == SLRU_PAGE_EMPTY ||
 		   (shared->page_status[slotno] == SLRU_PAGE_VALID &&
 			!shared->page_dirty[slotno]) ||
@@ -415,7 +415,7 @@ SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
 		bool		ok;
 
 		/* See if page already is in memory; if not, pick victim slot */
-		slotno = SlruSelectLRUPage(ctl, pageno);
+		slotno = SlruSelectLRUPage(ctl, pageno, min_lsn);
 
 		/* Did we find the page in memory? */
 		if (shared->page_number[slotno] == pageno &&
@@ -437,12 +437,6 @@ SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
 			}
 			/* Otherwise, it's ready to use */
 			SlruRecentlyUsed(shared, slotno);
-
-			if (min_lsn != InvalidXLogRecPtr ||
-			min_lsn <= shared->page_lsn[slotno]) {
-				// We have not found the page at the required lsn.
-				continue;
-			}
 
 			/* update the stats counter of pages found in the SLRU */
 			pgstat_count_slru_page_hit(shared->slru_stats_idx);
@@ -1101,7 +1095,7 @@ SlruReportIOError(SlruCtl ctl, int pageno, TransactionId xid)
  * Control lock must be held at entry, and will be held at exit.
  */
 static int
-SlruSelectLRUPage(SlruCtl ctl, int pageno)
+SlruSelectLRUPage(SlruCtl ctl, int pageno, XLogRecPtr min_lsn)
 {
 	SlruShared	shared = ctl->shared;
 
@@ -1121,8 +1115,10 @@ SlruSelectLRUPage(SlruCtl ctl, int pageno)
 		for (slotno = 0; slotno < shared->num_slots; slotno++)
 		{
 			if (shared->page_number[slotno] == pageno &&
-				shared->page_status[slotno] != SLRU_PAGE_EMPTY)
-				return slotno;
+				shared->page_status[slotno] != SLRU_PAGE_EMPTY &&
+				(min_lsn == InvalidXLogRecPtr ||
+				min_lsn <= shared->page_lsn[slotno]))
+			return slotno;
 		}
 
 		/*

--- a/src/backend/access/transam/subtrans.c
+++ b/src/backend/access/transam/subtrans.c
@@ -83,7 +83,8 @@ SubTransSetParent(TransactionId xid, TransactionId parent)
 
 	LWLockAcquire(SubtransSLRULock, LW_EXCLUSIVE);
 
-	slotno = SimpleLruReadPage(SubTransCtl, pageno, true, xid);
+	slotno = SimpleLruReadPage(SubTransCtl, pageno, true, xid,
+								InvalidXLogRecPtr);
 	ptr = (TransactionId *) SubTransCtl->shared->page_buffer[slotno];
 	ptr += entryno;
 
@@ -123,7 +124,8 @@ SubTransGetParent(TransactionId xid)
 
 	/* lock is acquired by SimpleLruReadPage_ReadOnly */
 
-	slotno = SimpleLruReadPage_ReadOnly(SubTransCtl, pageno, xid);
+	slotno = SimpleLruReadPage_ReadOnly(SubTransCtl, pageno, xid,
+										InvalidXLogRecPtr);
 	ptr = (TransactionId *) SubTransCtl->shared->page_buffer[slotno];
 	ptr += entryno;
 

--- a/src/backend/commands/async.c
+++ b/src/backend/commands/async.c
@@ -1456,7 +1456,7 @@ asyncQueueAddEntries(ListCell *nextNotify)
 		slotno = SimpleLruZeroPage(NotifyCtl, pageno);
 	else
 		slotno = SimpleLruReadPage(NotifyCtl, pageno, true,
-								   InvalidTransactionId);
+								   InvalidTransactionId, InvalidXLogRecPtr);
 
 	/* Note we mark the page dirty before writing in it */
 	NotifyCtl->shared->page_dirty[slotno] = true;
@@ -2007,8 +2007,9 @@ asyncQueueReadAllNotifications(void)
 			 * part of the page we will actually inspect.
 			 */
 			slotno = SimpleLruReadPage_ReadOnly(NotifyCtl, curpage,
-												InvalidTransactionId);
-			if (curpage == QUEUE_POS_PAGE(head))
+												InvalidTransactionId,
+												InvalidXLogRecPtr);
+            if (curpage == QUEUE_POS_PAGE(head))
 			{
 				/* we only want to read as far as head */
 				copysize = QUEUE_POS_OFFSET(head) - curoffset;

--- a/src/backend/storage/lmgr/predicate.c
+++ b/src/backend/storage/lmgr/predicate.c
@@ -961,9 +961,10 @@ SerialAdd(TransactionId xid, SerCommitSeqNo minConflictCommitSeqNo)
 		slotno = SimpleLruZeroPage(SerialSlruCtl, targetPage);
 	}
 	else
-		slotno = SimpleLruReadPage(SerialSlruCtl, targetPage, true, xid);
+		slotno = SimpleLruReadPage(SerialSlruCtl, targetPage, true, xid,
+									InvalidXLogRecPtr);
 
-	SerialValue(slotno, xid) = minConflictCommitSeqNo;
+    SerialValue(slotno, xid) = minConflictCommitSeqNo;
 	SerialSlruCtl->shared->page_dirty[slotno] = true;
 
 	LWLockRelease(SerialSLRULock);
@@ -1003,7 +1004,8 @@ SerialGetMinConflictCommitSeqNo(TransactionId xid)
 	 * but will return with that lock held, which must then be released.
 	 */
 	slotno = SimpleLruReadPage_ReadOnly(SerialSlruCtl,
-										SerialPage(xid), xid);
+										SerialPage(xid), xid, 
+										InvalidXLogRecPtr);
 	val = SerialValue(slotno, xid);
 	LWLockRelease(SerialSLRULock);
 	return val;

--- a/src/include/access/slru.h
+++ b/src/include/access/slru.h
@@ -42,9 +42,9 @@
 typedef enum
 {
 	SLRU_PAGE_EMPTY,			/* buffer is not in use */
-	SLRU_PAGE_READ_IN_PROGRESS, /* page is being read in */
+  SLRU_PAGE_READ_IN_PROGRESS, /* page is being read in */
 	SLRU_PAGE_VALID,			/* page is valid and not being written */
-	SLRU_PAGE_WRITE_IN_PROGRESS /* page is being written out */
+  SLRU_PAGE_WRITE_IN_PROGRESS /* page is being written out */
 } SlruPageStatus;
 
 /*
@@ -54,50 +54,51 @@ typedef struct SlruSharedData
 {
 	LWLock	   *ControlLock;
 
-	/* Number of buffers managed by this SLRU structure */
+  /* Number of buffers managed by this SLRU structure */
 	int			num_slots;
 
-	/*
-	 * Arrays holding info for each buffer slot.  Page number is undefined
-	 * when status is EMPTY, as is page_lru_count.
-	 */
+  /*
+   * Arrays holding info for each buffer slot.  Page number is undefined
+   * when status is EMPTY, as is page_lru_count.
+   */
 	char	  **page_buffer;
-	SlruPageStatus *page_status;
+  SlruPageStatus *page_status;
 	bool	   *page_dirty;
 	int		   *page_number;
 	int		   *page_lru_count;
-	LWLockPadded *buffer_locks;
+  XLogRecPtr *page_lsn;
+  LWLockPadded *buffer_locks;
 
-	/*
-	 * Optional array of WAL flush LSNs associated with entries in the SLRU
-	 * pages.  If not zero/NULL, we must flush WAL before writing pages (true
-	 * for pg_xact, false for multixact, pg_subtrans, pg_notify).  group_lsn[]
-	 * has lsn_groups_per_page entries per buffer slot, each containing the
-	 * highest LSN known for a contiguous group of SLRU entries on that slot's
-	 * page.
-	 */
-	XLogRecPtr *group_lsn;
+  /*
+   * Optional array of WAL flush LSNs associated with entries in the SLRU
+   * pages.  If not zero/NULL, we must flush WAL before writing pages (true
+   * for pg_xact, false for multixact, pg_subtrans, pg_notify).  group_lsn[]
+   * has lsn_groups_per_page entries per buffer slot, each containing the
+   * highest LSN known for a contiguous group of SLRU entries on that slot's
+   * page.
+   */
+  XLogRecPtr *group_lsn;
 	int			lsn_groups_per_page;
 
-	/*----------
-	 * We mark a page "most recently used" by setting
-	 *		page_lru_count[slotno] = ++cur_lru_count;
-	 * The oldest page is therefore the one with the highest value of
-	 *		cur_lru_count - page_lru_count[slotno]
-	 * The counts will eventually wrap around, but this calculation still
-	 * works as long as no page's age exceeds INT_MAX counts.
-	 *----------
-	 */
+  /*----------
+   * We mark a page "most recently used" by setting
+   *		page_lru_count[slotno] = ++cur_lru_count;
+   * The oldest page is therefore the one with the highest value of
+   *		cur_lru_count - page_lru_count[slotno]
+   * The counts will eventually wrap around, but this calculation still
+   * works as long as no page's age exceeds INT_MAX counts.
+   *----------
+   */
 	int			cur_lru_count;
 
-	/*
-	 * latest_page_number is the page number of the current end of the log;
-	 * this is not critical data, since we use it only to avoid swapping out
-	 * the latest page.
-	 */
+  /*
+   * latest_page_number is the page number of the current end of the log;
+   * this is not critical data, since we use it only to avoid swapping out
+   * the latest page.
+   */
 	int			latest_page_number;
 
-	/* SLRU's index for statistics purposes (might not be unique) */
+  /* SLRU's index for statistics purposes (might not be unique) */
 	int			slru_stats_idx;
 } SlruSharedData;
 
@@ -111,28 +112,28 @@ typedef struct SlruCtlData
 {
 	SlruShared	shared;
 
-	/*
-	 * Which sync handler function to use when handing sync requests over to
-	 * the checkpointer.  SYNC_HANDLER_NONE to disable fsync (eg pg_notify).
-	 */
-	SyncRequestHandler sync_handler;
+  /*
+   * Which sync handler function to use when handing sync requests over to
+   * the checkpointer.  SYNC_HANDLER_NONE to disable fsync (eg pg_notify).
+   */
+  SyncRequestHandler sync_handler;
 
-	/*
-	 * Decide whether a page is "older" for truncation and as a hint for
-	 * evicting pages in LRU order.  Return true if every entry of the first
-	 * argument is older than every entry of the second argument.  Note that
-	 * !PagePrecedes(a,b) && !PagePrecedes(b,a) need not imply a==b; it also
-	 * arises when some entries are older and some are not.  For SLRUs using
-	 * SimpleLruTruncate(), this must use modular arithmetic.  (For others,
-	 * the behavior of this callback has no functional implications.)  Use
-	 * SlruPagePrecedesUnitTests() in SLRUs meeting its criteria.
-	 */
+  /*
+   * Decide whether a page is "older" for truncation and as a hint for
+   * evicting pages in LRU order.  Return true if every entry of the first
+   * argument is older than every entry of the second argument.  Note that
+   * !PagePrecedes(a,b) && !PagePrecedes(b,a) need not imply a==b; it also
+   * arises when some entries are older and some are not.  For SLRUs using
+   * SimpleLruTruncate(), this must use modular arithmetic.  (For others,
+   * the behavior of this callback has no functional implications.)  Use
+   * SlruPagePrecedesUnitTests() in SLRUs meeting its criteria.
+   */
 	bool		(*PagePrecedes) (int, int);
 
-	/*
-	 * Dir is set during SimpleLruInit and does not change thereafter. Since
-	 * it's always the same, it doesn't need to be in shared memory.
-	 */
+  /*
+   * Dir is set during SimpleLruInit and does not change thereafter. Since
+   * it's always the same, it doesn't need to be in shared memory.
+   */
 	char		Dir[64];
 } SlruCtlData;
 
@@ -140,20 +141,20 @@ typedef SlruCtlData *SlruCtl;
 
 typedef bool (*slru_kind_check_hook_type) (SlruCtl ctl);
 typedef bool (*slru_page_exists_hook_type) (SlruCtl ctl, int segno, off_t offset);
-typedef bool (*slru_read_page_hook_type) (SlruCtl ctl, int segno, off_t offset, char *buffer);
+typedef bool (*slru_read_page_hook_type) (SlruCtl ctl, int segno, off_t offset, XLogRecPtr min_lsn, char *buffer);
 extern PGDLLIMPORT slru_kind_check_hook_type slru_kind_check_hook;
 extern PGDLLIMPORT slru_page_exists_hook_type slru_page_exists_hook;
 extern PGDLLIMPORT slru_read_page_hook_type slru_read_page_hook;
 
 extern Size SimpleLruShmemSize(int nslots, int nlsns);
 extern void SimpleLruInit(SlruCtl ctl, const char *name, int nslots, int nlsns,
-						  LWLock *ctllock, const char *subdir, int tranche_id,
-						  SyncRequestHandler sync_handler);
+                          LWLock *ctllock, const char *subdir, int tranche_id,
+                          SyncRequestHandler sync_handler);
 extern int	SimpleLruZeroPage(SlruCtl ctl, int pageno);
 extern int	SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
-							  TransactionId xid);
-extern int	SimpleLruReadPage_ReadOnly(SlruCtl ctl, int pageno,
-									   TransactionId xid);
+                             XLogRecPtr min_lsn, TransactionId xid);
+extern int  SimpleLruReadPage_ReadOnly(SlruCtl ctl, int pageno,
+                                       XLogRecPtr min_lsn, TransactionId xid);
 extern void SimpleLruWritePage(SlruCtl ctl, int slotno);
 extern void SimpleLruWriteAll(SlruCtl ctl, bool allow_redirtied);
 #ifdef USE_ASSERT_CHECKING
@@ -165,7 +166,7 @@ extern void SimpleLruTruncate(SlruCtl ctl, int cutoffPage);
 extern bool SimpleLruDoesPhysicalPageExist(SlruCtl ctl, int pageno);
 
 typedef bool (*SlruScanCallback) (SlruCtl ctl, char *filename, int segpage,
-								  void *data);
+                                 void *data);
 extern bool SlruScanDirectory(SlruCtl ctl, SlruScanCallback callback, void *data);
 extern void SlruDeleteSegment(SlruCtl ctl, int segno);
 
@@ -173,8 +174,8 @@ extern int	SlruSyncFileTag(SlruCtl ctl, const FileTag *ftag, char *path);
 
 /* SlruScanDirectory public callbacks */
 extern bool SlruScanDirCbReportPresence(SlruCtl ctl, char *filename,
-										int segpage, void *data);
+                                        int segpage, void *data);
 extern bool SlruScanDirCbDeleteAll(SlruCtl ctl, char *filename, int segpage,
-								   void *data);
+                                   void *data);
 
 #endif							/* SLRU_H */


### PR DESCRIPTION
@ctring I have added the framework to send a specific LSN to the read. The only place we need to change in csn_log.c wherein we read to get the XidCsn mapping for a given Xid. Since you know the code wherein you can get the region_id and the corresponding LSN for it, can you please add it. 

Also, this will only work if you also merge https://github.com/DSLAM-UMD/neon/pull/11