### PR TITLE
Define a PROC_IS_REMOTEXACT statusFlag option

### DIFF
--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -65,6 +65,7 @@ struct XidCache
 #define		PROC_AFFECTS_ALL_HORIZONS	0x20	/* this proc's xmin must be
 												 * included in vacuum horizons
 												 * in all databases */
+#define		PROC_IS_REMOTEXACT 0x40 	/* currently running a remotexact */
 
 /* flags reset at EOXact */
 #define		PROC_VACUUM_STATE_MASK \


### PR DESCRIPTION
Same as #21, it was probably lost in the rebase. 