### PR TITLE
Fix a bug in the arguments of SLRU read functions

### DIFF
--- a/src/backend/access/transam/clog.c
+++ b/src/backend/access/transam/clog.c
@@ -359,7 +359,7 @@ TransactionIdSetPageStatusInternal(TransactionId xid, int nsubxids,
 	 * we think.
 	 */
 	slotno = SimpleLruReadPage(XactCtl, pageno, XLogRecPtrIsInvalid(lsn),
-								xid, InvalidXLogRecPtr);
+							   xid, InvalidXLogRecPtr);
 
         /*
 	 * Set the main transaction id, if any.
@@ -800,8 +800,7 @@ TrimCLOG(void)
 		int			slotno;
 		char	   *byteptr;
 
-		slotno = SimpleLruReadPage(XactCtl, pageno, false, xid,
-									InvalidXLogRecPtr);
+		slotno = SimpleLruReadPage(XactCtl, pageno, false, xid, InvalidXLogRecPtr);
 		byteptr = XactCtl->shared->page_buffer[slotno] + byteno;
 
 		/* Zero so-far-unused positions in the current byte */

--- a/src/backend/access/transam/commit_ts.c
+++ b/src/backend/access/transam/commit_ts.c
@@ -222,8 +222,7 @@ SetXidCommitTsInPage(TransactionId xid, int nsubxids,
 
 	LWLockAcquire(CommitTsSLRULock, LW_EXCLUSIVE);
 
-	slotno = SimpleLruReadPage(CommitTsCtl, pageno, true, xid,
-								InvalidXLogRecPtr);
+	slotno = SimpleLruReadPage(CommitTsCtl, pageno, true, xid, InvalidXLogRecPtr);
 
         TransactionIdSetCommitTs(xid, ts, nodeid, slotno);
 	for (i = 0; i < nsubxids; i++)
@@ -328,8 +327,7 @@ TransactionIdGetCommitTsData(TransactionId xid, TimestampTz *ts,
 	}
 
 	/* lock is acquired by SimpleLruReadPage_ReadOnly */
-	slotno = SimpleLruReadPage_ReadOnly(CommitTsCtl, pageno, xid,
-										InvalidXLogRecPtr);
+	slotno = SimpleLruReadPage_ReadOnly(CommitTsCtl, pageno, xid, InvalidXLogRecPtr);
 	memcpy(&entry,
 		   CommitTsCtl->shared->page_buffer[slotno] +
 		   SizeOfCommitTimestampEntry * entryno,

--- a/src/backend/access/transam/multixact.c
+++ b/src/backend/access/transam/multixact.c
@@ -881,8 +881,7 @@ RecordNewMultiXact(MultiXactId multi, MultiXactOffset offset,
 	 * enough that a MultiXactId is really involved.  Perhaps someday we'll
 	 * take the trouble to generalize the slru.c error reporting code.
 	 */
-	slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true, multi,
-								InvalidXLogRecPtr);
+	slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true, multi, InvalidXLogRecPtr);
 	offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
 	offptr += entryno;
 
@@ -916,7 +915,7 @@ RecordNewMultiXact(MultiXactId multi, MultiXactOffset offset,
 		if (pageno != prev_pageno)
 		{
 			slotno = SimpleLruReadPage(MultiXactMemberCtl, pageno, true,
-										multi, InvalidXLogRecPtr);
+									   multi, InvalidXLogRecPtr);
 			prev_pageno = pageno;
 		}
 
@@ -1347,8 +1346,7 @@ retry:
 	pageno = MultiXactIdToOffsetPage(multi);
 	entryno = MultiXactIdToOffsetEntry(multi);
 
-	slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true, multi,
-								InvalidXLogRecPtr);
+	slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true, multi, InvalidXLogRecPtr);
 	offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
 	offptr += entryno;
 	offset = *offptr;
@@ -1381,7 +1379,7 @@ retry:
 
 		if (pageno != prev_pageno)
 			slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true,
-										tmpMXact, InvalidXLogRecPtr);
+									   tmpMXact, InvalidXLogRecPtr);
 
         offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
 		offptr += entryno;
@@ -1422,7 +1420,7 @@ retry:
 		if (pageno != prev_pageno)
 		{
 			slotno = SimpleLruReadPage(MultiXactMemberCtl, pageno, true,
-										multi, InvalidXLogRecPtr);
+									   multi, InvalidXLogRecPtr);
 			prev_pageno = pageno;
 		}
 
@@ -2074,7 +2072,7 @@ TrimMultiXact(void)
 		MultiXactOffset *offptr;
 
 		slotno = SimpleLruReadPage(MultiXactOffsetCtl, pageno, true,
-									nextMXact, InvalidXLogRecPtr);
+								   nextMXact, InvalidXLogRecPtr);
 		offptr = (MultiXactOffset *) MultiXactOffsetCtl->shared->page_buffer[slotno];
 		offptr += entryno;
 
@@ -2107,7 +2105,7 @@ TrimMultiXact(void)
 
 		memberoff = MXOffsetToMemberOffset(offset);
 		slotno = SimpleLruReadPage(MultiXactMemberCtl, pageno, true,
-									offset, InvalidXLogRecPtr);
+								   offset, InvalidXLogRecPtr);
         xidptr = (TransactionId *)
 			(MultiXactMemberCtl->shared->page_buffer[slotno] + memberoff);
 

--- a/src/backend/access/transam/slru.c
+++ b/src/backend/access/transam/slru.c
@@ -171,7 +171,7 @@ SimpleLruShmemSize(int nslots, int nlsns)
 	sz += MAXALIGN(nslots * sizeof(int));	/* page_number[] */
 	sz += MAXALIGN(nslots * sizeof(int));	/* page_lru_count[] */
 	sz += MAXALIGN(nslots * sizeof(XLogRecPtr));	/* page_lsn[] */
-	sz += MAXALIGN(nslots * sizeof(LWLockPadded)); /* buffer_locks[] */
+	sz += MAXALIGN(nslots * sizeof(LWLockPadded));	/* buffer_locks[] */
 
 	if (nlsns > 0)
 		sz += MAXALIGN(nslots * nlsns * sizeof(XLogRecPtr));	/* group_lsn[] */
@@ -303,8 +303,8 @@ SimpleLruZeroPage(SlruCtl ctl, int pageno)
 	shared->page_number[slotno] = pageno;
 	shared->page_status[slotno] = SLRU_PAGE_VALID;
 	shared->page_dirty[slotno] = true;
-	SlruRecentlyUsed(shared, slotno);
 	shared->page_lsn[slotno] = InvalidXLogRecPtr;
+	SlruRecentlyUsed(shared, slotno);
 
 	/* Set the buffer to zeroes */
 	MemSet(shared->page_buffer[slotno], 0, BLCKSZ);
@@ -403,8 +403,8 @@ SimpleLruWaitIO(SlruCtl ctl, int slotno)
  * Control lock must be held at entry, and will be held at exit.
  */
 int
-SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
-				  XLogRecPtr min_lsn, TransactionId xid)
+SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok, TransactionId xid,
+				  XLogRecPtr min_lsn)
 {
 	SlruShared	shared = ctl->shared;
 
@@ -421,7 +421,7 @@ SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
 		if (shared->page_number[slotno] == pageno &&
 			shared->page_status[slotno] != SLRU_PAGE_EMPTY &&
 			(min_lsn == InvalidXLogRecPtr ||
-			min_lsn <= shared->page_lsn[slotno]))
+			 min_lsn <= shared->page_lsn[slotno]))
 		{
 			/*
 			 * If page is still being read in, we must wait for I/O.  Likewise
@@ -506,8 +506,7 @@ SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
  * It is unspecified whether the lock will be shared or exclusive.
  */
 int
-SimpleLruReadPage_ReadOnly(SlruCtl ctl, int pageno, XLogRecPtr min_lsn,
-						   TransactionId xid)
+SimpleLruReadPage_ReadOnly(SlruCtl ctl, int pageno, TransactionId xid, XLogRecPtr min_lsn)
 {
 	SlruShared	shared = ctl->shared;
 	int			slotno;
@@ -525,7 +524,7 @@ SimpleLruReadPage_ReadOnly(SlruCtl ctl, int pageno, XLogRecPtr min_lsn,
 			shared->page_status[slotno] != SLRU_PAGE_EMPTY &&
 			shared->page_status[slotno] != SLRU_PAGE_READ_IN_PROGRESS &&
 			(min_lsn == InvalidXLogRecPtr ||
-			min_lsn <= shared->page_lsn[slotno]))
+			 min_lsn <= shared->page_lsn[slotno]))
 		{
 			/* See comments for SlruRecentlyUsed macro */
 			SlruRecentlyUsed(shared, slotno);
@@ -1117,7 +1116,7 @@ SlruSelectLRUPage(SlruCtl ctl, int pageno, XLogRecPtr min_lsn)
 			if (shared->page_number[slotno] == pageno &&
 				shared->page_status[slotno] != SLRU_PAGE_EMPTY &&
 				(min_lsn == InvalidXLogRecPtr ||
-				min_lsn <= shared->page_lsn[slotno]))
+				 min_lsn <= shared->page_lsn[slotno]))
 			return slotno;
 		}
 

--- a/src/backend/access/transam/subtrans.c
+++ b/src/backend/access/transam/subtrans.c
@@ -83,8 +83,7 @@ SubTransSetParent(TransactionId xid, TransactionId parent)
 
 	LWLockAcquire(SubtransSLRULock, LW_EXCLUSIVE);
 
-	slotno = SimpleLruReadPage(SubTransCtl, pageno, true, xid,
-								InvalidXLogRecPtr);
+	slotno = SimpleLruReadPage(SubTransCtl, pageno, true, xid, InvalidXLogRecPtr);
 	ptr = (TransactionId *) SubTransCtl->shared->page_buffer[slotno];
 	ptr += entryno;
 

--- a/src/backend/storage/lmgr/predicate.c
+++ b/src/backend/storage/lmgr/predicate.c
@@ -962,7 +962,7 @@ SerialAdd(TransactionId xid, SerCommitSeqNo minConflictCommitSeqNo)
 	}
 	else
 		slotno = SimpleLruReadPage(SerialSlruCtl, targetPage, true, xid,
-									InvalidXLogRecPtr);
+								   InvalidXLogRecPtr);
 
     SerialValue(slotno, xid) = minConflictCommitSeqNo;
 	SerialSlruCtl->shared->page_dirty[slotno] = true;

--- a/src/include/access/slru.h
+++ b/src/include/access/slru.h
@@ -152,9 +152,9 @@ extern void SimpleLruInit(SlruCtl ctl, const char *name, int nslots, int nlsns,
                           SyncRequestHandler sync_handler);
 extern int	SimpleLruZeroPage(SlruCtl ctl, int pageno);
 extern int	SimpleLruReadPage(SlruCtl ctl, int pageno, bool write_ok,
-                             XLogRecPtr min_lsn, TransactionId xid);
+                              TransactionId xid, XLogRecPtr min_lsn);
 extern int  SimpleLruReadPage_ReadOnly(SlruCtl ctl, int pageno,
-                                       XLogRecPtr min_lsn, TransactionId xid);
+                                       TransactionId xid, XLogRecPtr min_lsn);
 extern void SimpleLruWritePage(SlruCtl ctl, int slotno);
 extern void SimpleLruWriteAll(SlruCtl ctl, bool allow_redirtied);
 #ifdef USE_ASSERT_CHECKING
@@ -166,7 +166,7 @@ extern void SimpleLruTruncate(SlruCtl ctl, int cutoffPage);
 extern bool SimpleLruDoesPhysicalPageExist(SlruCtl ctl, int pageno);
 
 typedef bool (*SlruScanCallback) (SlruCtl ctl, char *filename, int segpage,
-                                 void *data);
+                                  void *data);
 extern bool SlruScanDirectory(SlruCtl ctl, SlruScanCallback callback, void *data);
 extern void SlruDeleteSegment(SlruCtl ctl, int segno);
 


### PR DESCRIPTION
The order of `xid` and `min_lsn` in `SimpleLruReadPage` and `SimpleLruReadPage_ReadOnly` wasn't consistent with how they are used (see slru.h)