### PR TITLE
Parameterize csn functions by region & clean up

### DIFF
--- a/src/backend/access/transam/csn_log.c
+++ b/src/backend/access/transam/csn_log.c
@@ -76,7 +76,7 @@ CSNshapshotShared csnShared = NULL;
  * region = current_region for all writes and relation's region for reads.
  */
 #define TransactionIdToPage(xid, region) \
-  (((xid / (TransactionId)CSN_LOG_XACTS_PER_PAGE) * MAX_REGIONS) + region)
+	(((xid / (TransactionId)CSN_LOG_XACTS_PER_PAGE) * MAX_REGIONS) + region)
 #define TransactionIdToPgIndex(xid) ((xid) % (TransactionId) CSN_LOG_XACTS_PER_PAGE)
 
 /*
@@ -89,13 +89,10 @@ static int	ZeroCSNLogPage(int pageno, bool write_xlog);
 static void ZeroTruncateCSNLogPage(int pageno, bool write_xlog);
 static bool CSNLogPagePrecedes(int page1, int page2);
 static void CSNLogSetPageStatus(TransactionId xid, int nsubxids,
-									  TransactionId *subxids,
-									  XidCSN csn, int pageno);
-static void CSNLogSetCSNInSlot(TransactionId xid, XidCSN csn,
-									  int slotno);
+								TransactionId *subxids,
+								XidCSN csn, int pageno);
+static void CSNLogSetCSNInSlot(TransactionId xid, XidCSN csn, int slotno);
 
-static void WriteXidCsnXlogRec(TransactionId xid, int nsubxids,
-					 TransactionId *subxids, XidCSN csn);
 static void WriteZeroCSNPageXlogRec(int pageno);
 static void WriteTruncateCSNXlogRec(int pageno);
 
@@ -116,7 +113,7 @@ static void WriteTruncateCSNXlogRec(int pageno);
  */
 void
 CSNLogSetCSN(TransactionId xid, int nsubxids,
-					 TransactionId *subxids, XidCSN csn, bool write_xlog)
+			 TransactionId *subxids, XidCSN csn, bool write_xlog)
 {
 	int			pageno;
 	int			i = 0;
@@ -125,10 +122,6 @@ CSNLogSetCSN(TransactionId xid, int nsubxids,
 	Assert(TransactionIdIsValid(xid));
 
 	pageno = TransactionIdToPage(xid, current_region);  /* get page of parent */
-
-	// TODO(pooja): Remove this part entirely?
-	// if(write_xlog)
-	// 	WriteXidCsnXlogRec(xid, nsubxids, subxids, csn);
 
 	for (;;)
 	{
@@ -158,8 +151,8 @@ CSNLogSetCSN(TransactionId xid, int nsubxids,
  */
 static void
 CSNLogSetPageStatus(TransactionId xid, int nsubxids,
-						   TransactionId *subxids,
-						   XidCSN csn, int pageno)
+					TransactionId *subxids,
+					XidCSN csn, int pageno)
 {
 	int			slotno;
 	int			i;
@@ -210,15 +203,17 @@ CSNLogSetCSNInSlot(TransactionId xid, XidCSN csn, int slotno)
  * intended caller.
  */
 XidCSN
-CSNLogGetCSNByXid(TransactionId xid)
+CSNLogGetCSNByXid(int region, TransactionId xid)
 {
-	// TODO(pooja): Use region based on relation instead of current_region.
-	int			pageno = TransactionIdToPage(xid, current_region);
+	int			pageno = TransactionIdToPage(xid, region);
 	int			entryno = TransactionIdToPgIndex(xid);
 	int			slotno;
 	XLogRecPtr  min_lsn = InvalidXLogRecPtr;
 	XidCSN *ptr;
 	XidCSN	xid_csn;
+
+	if (RegionIsRemote(region))
+		min_lsn = GetRegionLsn(region);
 
 	/* lock is acquired by SimpleLruReadPage_ReadOnly */
 	slotno = SimpleLruReadPage_ReadOnly(CsnlogCtl, pageno, xid, min_lsn);
@@ -264,8 +259,8 @@ CSNLogShmemInit(void)
 				  SYNC_HANDLER_CSN);
 
 	csnShared = (CSNshapshotShared) ShmemInitStruct("CSNlog shared",
-									 sizeof(CSNshapshotSharedData),
-									 &found);
+									 				sizeof(CSNshapshotSharedData),
+													&found);
 }
 
 /*
@@ -486,7 +481,7 @@ CSNLogPagePrecedes(int page1, int page2)
 
     // Either of the pages don't belong to the current region, so return false.
     if (((page1 - current_region) % MAX_REGIONS != 0) ||
-        	((page2 - current_region) % MAX_REGIONS != 0)) {
+        ((page2 - current_region) % MAX_REGIONS != 0)) {
         return false;
     }
 
@@ -506,30 +501,13 @@ WriteAssignCSNXlogRec(XidCSN xidcsn)
 	XidCSN log_csn = 0;
 
 	if(xidcsn <= get_last_log_wal_csn())
-	{
 		return;
-	}
+
 	log_csn = xidcsn;
 
 	XLogBeginInsert();
 	XLogRegisterData((char *) (&log_csn), sizeof(XidCSN));
 	XLogInsert(RM_CSNLOG_ID, XLOG_CSN_ASSIGNMENT);
-}
-
-static void
-WriteXidCsnXlogRec(TransactionId xid, int nsubxids,
-					 TransactionId *subxids, XidCSN csn)
-{
-	xl_xidcsn_set 	xlrec;
-
-	xlrec.xtop = xid;
-	xlrec.nsubxacts = nsubxids;
-	xlrec.xidcsn = csn;
-
-	XLogBeginInsert();
-	XLogRegisterData((char *) &xlrec, MinSizeOfXidCSNSet);
-	XLogRegisterData((char *) subxids, nsubxids * sizeof(TransactionId));
-	XLogInsert(RM_CSNLOG_ID, XLOG_CSN_SETXIDCSN);
 }
 
 /*

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2216,7 +2216,6 @@ GetSnapshotData(Snapshot snapshot)
 	int			count = 0;
 	int			subcount = 0;
 	bool		suboverflowed = false;
-	XidCSN	xid_csn = FrozenXidCSN;
 	FullTransactionId latest_completed;
 	TransactionId oldestxid;
 	int			mypgxactoff;
@@ -2449,13 +2448,6 @@ GetSnapshotData(Snapshot snapshot)
 	if (!TransactionIdIsValid(MyProc->xmin))
 		MyProc->xmin = TransactionXmin = xmin;
 
-	/*
-	 * Take XidCSN under ProcArrayLock so the snapshot stays
-	 * synchronized.
-	 */
-	if (!snapshot->takenDuringRecovery && get_csnlog_status())
-		xid_csn = GetLastAssignedCSN(false);
-
 	LWLockRelease(ProcArrayLock);
 
 	/* maintain state for GlobalVis* */
@@ -2563,7 +2555,6 @@ GetSnapshotData(Snapshot snapshot)
 	snapshot->copied = false;
 
 	GetSnapshotDataInitOldSnapshot(snapshot);
-	snapshot->snapshot_csn = xid_csn;
 
 	return snapshot;
 }

--- a/src/include/access/csn_log.h
+++ b/src/include/access/csn_log.h
@@ -33,8 +33,8 @@ typedef struct xl_xidcsn_set
 
 
 extern void CSNLogSetCSN(TransactionId xid, int nsubxids,
-							TransactionId *subxids, XidCSN csn, bool write_xlog);
-extern XidCSN CSNLogGetCSNByXid(TransactionId xid);
+						 TransactionId *subxids, XidCSN csn, bool write_xlog);
+extern XidCSN CSNLogGetCSNByXid(int region, TransactionId xid);
 
 extern Size CSNLogShmemSize(void);
 extern void CSNLogShmemInit(void);

--- a/src/include/access/csn_snapshot.h
+++ b/src/include/access/csn_snapshot.h
@@ -37,23 +37,21 @@ typedef pg_atomic_uint64 CSN_atomic;
 #define XidCSNIsNormal(csn)		((csn) >= FirstNormalXidCSN)
 
 
-
-
 extern Size CSNSnapshotShmemSize(void);
 extern void CSNSnapshotShmemInit(void);
 
 extern SnapshotCSN GetLastAssignedCSN(bool locked);
 extern void SetAssignedCSN(PGPROC *proc, SnapshotCSN csn, bool locked);
 
-extern bool XidInvisibleInCSNSnapshot(TransactionId xid, Snapshot snapshot);
+// extern bool XidInvisibleInCSNSnapshot(TransactionId xid, Snapshot snapshot);
 
-extern XidCSN TransactionIdGetXidCSN(TransactionId xid);
+extern XidCSN TransactionIdGetXidCSN(int region, TransactionId xid);
 
 extern void CSNSnapshotAbort(PGPROC *proc, TransactionId xid, int nsubxids,
-								TransactionId *subxids);
+							 TransactionId *subxids);
 extern void CSNSnapshotPrecommit(PGPROC *proc, TransactionId xid, int nsubxids,
-									TransactionId *subxids);
+								 TransactionId *subxids);
 extern void CSNSnapshotCommit(PGPROC *proc, TransactionId xid, int nsubxids,
-									TransactionId *subxids);
+							  TransactionId *subxids);
 
 #endif							/* CSN_SNAPSHOT_H */

--- a/src/include/utils/snapshot.h
+++ b/src/include/utils/snapshot.h
@@ -212,12 +212,6 @@ typedef struct SnapshotData
 	XLogRecPtr	lsn;			/* position in the WAL stream when taken */
 
 	/*
-	 * SnapshotCSN for snapshot isolation support.
-	 * Will be used only if enable_csn_snapshot is enabled.
-	 */
-	SnapshotCSN	snapshot_csn;
-
-	/*
 	 * The transaction completion count at the time GetSnapshotData() built
 	 * this snapshot. Allows to avoid re-computing static snapshots when no
 	 * transactions completed since the last GetSnapshotData().


### PR DESCRIPTION
+ Add `region` argument to `CSNLogGetCSNByXid` and `TransactionIdGetXidCSN`.
+ Remove `snapshot_csn` from snapshot.
+ We won't need to use csn to check visibility in `XidInMVCCSnapshot` so commenting it out.