### PR TITLE
Visibility checking for tuples on remote tables

### DIFF
--- a/src/backend/access/transam/csn_snapshot.c
+++ b/src/backend/access/transam/csn_snapshot.c
@@ -30,9 +30,6 @@
 #include "utils/snapmgr.h"
 #include "miscadmin.h"
 
-/* Raise a warning if imported snapshot_csn exceeds ours by this value. */
-#define SNAP_DESYNC_COMPLAIN (1*NSECS_PER_SEC) /* 1 second */
-
 TransactionId 	 xmin_for_csn = InvalidTransactionId;
 
 /*
@@ -81,35 +78,6 @@ CSNSnapshotShmemInit()
 		csnState->last_csn_log_wal = 0;
 		SpinLockInit(&csnState->lock);
 	}
-}
-
-/*
- * GetLastAssignedCSN
- *
- * Return last assigned SnapshotCSN which is actually the last assigned LSN. 
- * If the CSN record has not been persisted, call WriteAssignCSNXlogRec().  
- */
-SnapshotCSN
-GetLastAssignedCSN(bool locked)
-{
-	SnapshotCSN	csn;
-
-	Assert(get_csnlog_status());
-	csn = (SnapshotCSN) GetFlushRecPtr();
-
-	/* TODO: change to atomics? */
-	if (!locked)
-		SpinLockAcquire(&csnState->lock);
-
-	if (csn > csnState->last_max_csn)
-		csnState->last_max_csn = csn;
-
-	WriteAssignCSNXlogRec(csn);
-
-	if (!locked)
-		SpinLockRelease(&csnState->lock);
-
-	return csn;
 }
 
 /*
@@ -167,7 +135,7 @@ TransactionIdGetXidCSN(int region, TransactionId xid)
 
 	/*
 	 * If we just switch a xid-snapsot to a csn_snapshot, we should handle a start
-	 * xid for csn basse check. Just in case we have prepared transaction which
+	 * xid for csn base check. Just in case we have prepared transaction which
 	 * hold the TransactionXmin but without CSN.
 	 */
 	if (InvalidTransactionId == xmin_for_csn)
@@ -200,7 +168,7 @@ TransactionIdGetXidCSN(int region, TransactionId xid)
 	xid_csn = CSNLogGetCSNByXid(region, xid);
 
 	/*
-	 * If we faced InDoubt state then transaction is beeing committed and we
+	 * If we faced InDoubt state then transaction is being committed and we
 	 * should wait until XidCSN will be assigned so that visibility check
 	 * could decide whether tuple is in snapshot. See also comments in
 	 * CSNSnapshotPrecommit().
@@ -218,48 +186,6 @@ TransactionIdGetXidCSN(int region, TransactionId xid)
 
 	return xid_csn;
 }
-
-/*
- * XidInvisibleInCSNSnapshot
- *
- * Version of XidInMVCCSnapshot for transactions. For non-imported
- * csn snapshots this should give same results as XidInLocalMVCCSnapshot
- * (except that aborts will be shown as invisible without going to clog) and to
- * ensure such behaviour XidInMVCCSnapshot is coated with asserts that checks
- * identicalness of XidInvisibleInCSNSnapshot/XidInLocalMVCCSnapshot in
- * case of ordinary snapshot.
- */
-// bool
-// XidInvisibleInCSNSnapshot(TransactionId xid, Snapshot snapshot)
-// {
-// 	XidCSN csn;
-
-// 	Assert(get_csnlog_status());
-
-// 	csn = TransactionIdGetXidCSN(xid);
-
-// 	if (XidCSNIsNormal(csn))
-// 	{
-// 		if (csn < snapshot->snapshot_csn)
-// 			return false;
-// 		else
-// 			return true;
-// 	}
-// 	else if (XidCSNIsFrozen(csn))
-// 	{
-// 		/* It is bootstrap or frozen transaction */
-// 		return false;
-// 	}
-// 	else
-// 	{
-// 		/* It is aborted or in-progress */
-// 		Assert(XidCSNIsAborted(csn) || XidCSNIsInProgress(csn));
-// 		if (XidCSNIsAborted(csn))
-// 			Assert(TransactionIdDidAbort(xid));
-// 		return true;
-// 	}
-// }
-
 
 /*****************************************************************************
  * Functions to handle transactions commit.

--- a/src/backend/access/transam/transam.c
+++ b/src/backend/access/transam/transam.c
@@ -20,6 +20,9 @@
 #include "postgres.h"
 
 #include "access/clog.h"
+#include "access/csn_log.h"
+#include "access/csn_snapshot.h"
+#include "access/remotexact.h"
 #include "access/subtrans.h"
 #include "access/transam.h"
 #include "utils/snapmgr.h"
@@ -168,6 +171,47 @@ TransactionIdDidCommit(TransactionId transactionId)
 	 * It's not committed.
 	 */
 	return false;
+}
+
+/*
+ * RemoteTransactionIdDidCommit
+ *		True iff transaction associated with the remote identifier did commit.
+ *
+ * Note:
+ *		Assumes transaction identifier is valid and exists in csn_log.
+ *
+ * Remotexact
+ */
+bool							/* true if given transaction committed */
+RemoteTransactionIdDidCommit(int region, TransactionId transactionId)
+{
+	XidCSN csn;
+
+	// TODO (ctring): cache the fetched id like in TransactionLogFetch?
+
+	/*
+	 * Also, check to see if the transaction ID is a permanent one.
+	 */
+	if (!TransactionIdIsNormal(transactionId))
+	{
+		if (TransactionIdEquals(transactionId, BootstrapTransactionId))
+			return true;
+		if (TransactionIdEquals(transactionId, FrozenTransactionId))
+			return true;
+		return false;
+	}
+
+	/*
+	 * Get the csn corresponding to the transaction id.
+	 */
+	csn = CSNLogGetCSNByXid(region, transactionId);
+
+	/*
+	 * An XID is committed if it has a frozen CSN or a normal CSN that
+	 * is not newer than the LSN snapshot of the given region 
+	 */
+	return XidCSNIsFrozen(csn) || (
+		   XidCSNIsNormal(csn) && csn <= GetRegionLsn(region));
 }
 
 /*

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -174,7 +174,6 @@ static TimestampTz AlignTimestampToMinuteBoundary(TimestampTz ts);
 static Snapshot CopySnapshot(Snapshot snapshot);
 static void FreeSnapshot(Snapshot snapshot);
 static void SnapshotResetXmin(void);
-static bool XidInLocalMVCCSnapshot(TransactionId xid, Snapshot snapshot);
 
 /*
  * Snapshot fields to be serialized.
@@ -2249,45 +2248,6 @@ RestoreTransactionSnapshot(Snapshot snapshot, void *source_pgproc)
 
 /*
  * XidInMVCCSnapshot
- *
- * Check whether this xid is in snapshot. When enable_csn_snapshot is
- * switched off just call XidInLocalMVCCSnapshot().
- */
-bool
-XidInMVCCSnapshot(TransactionId xid, Snapshot snapshot)
-{
-//	bool in_snapshot;
-	return XidInLocalMVCCSnapshot(xid, snapshot);
-// 	if (!get_csnlog_status())
-// 	{
-// 		Assert(XidCSNIsFrozen(snapshot->snapshot_csn));
-// 		return in_snapshot;
-// 	}
-
-// 	if (in_snapshot)
-// 	{
-// 		/*
-// 		 * This xid may be already in unknown state and in that case
-// 		 * we must wait and recheck.
-// 		 */
-// 		return XidInvisibleInCSNSnapshot(xid, snapshot);
-// 	}
-// 	else
-// 	{
-// #ifdef USE_ASSERT_CHECKING
-// 		/* Check that csn snapshot gives the same results as local one */
-// 		if (XidInvisibleInCSNSnapshot(xid, snapshot))
-// 		{
-// 			XidCSN gcsn = TransactionIdGetXidCSN(xid);
-// 			Assert(XidCSNIsAborted(gcsn) || XidCSNIsInProgress(gcsn));
-// 		}
-// #endif
-// 		return false;
-// 	}
-}
-
-/*
- * XidInLocalMVCCSnapshot
  *		Is the given XID still-in-progress according to the snapshot?
  *
  * Note: GetSnapshotData never stores either top xid or subxids of our own
@@ -2296,8 +2256,8 @@ XidInMVCCSnapshot(TransactionId xid, Snapshot snapshot)
  * TransactionIdIsCurrentTransactionId first, except when it's known the
  * XID could not be ours anyway.
  */
-static bool
-XidInLocalMVCCSnapshot(TransactionId xid, Snapshot snapshot)
+bool
+XidInMVCCSnapshot(TransactionId xid, Snapshot snapshot)
 {
 	uint32		i;
 

--- a/src/include/access/csn_snapshot.h
+++ b/src/include/access/csn_snapshot.h
@@ -31,19 +31,15 @@ typedef pg_atomic_uint64 CSN_atomic;
 #define FirstNormalXidCSN 		UINT64CONST(0x4)
 
 #define XidCSNIsInProgress(csn)	((csn) == InProgressXidCSN)
-#define XidCSNIsAborted(csn)		((csn) == AbortedXidCSN)
+#define XidCSNIsAborted(csn)	((csn) == AbortedXidCSN)
 #define XidCSNIsFrozen(csn)		((csn) == FrozenXidCSN)
-#define XidCSNIsInDoubt(csn)		((csn) == InDoubtXidCSN)
+#define XidCSNIsInDoubt(csn)	((csn) == InDoubtXidCSN)
 #define XidCSNIsNormal(csn)		((csn) >= FirstNormalXidCSN)
-
 
 extern Size CSNSnapshotShmemSize(void);
 extern void CSNSnapshotShmemInit(void);
 
-extern SnapshotCSN GetLastAssignedCSN(bool locked);
 extern void SetAssignedCSN(PGPROC *proc, SnapshotCSN csn, bool locked);
-
-// extern bool XidInvisibleInCSNSnapshot(TransactionId xid, Snapshot snapshot);
 
 extern XidCSN TransactionIdGetXidCSN(int region, TransactionId xid);
 

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -267,6 +267,7 @@ extern PGDLLIMPORT VariableCache ShmemVariableCache;
  * prototypes for functions in transam/transam.c
  */
 extern bool TransactionIdDidCommit(TransactionId transactionId);
+extern bool RemoteTransactionIdDidCommit(int region, TransactionId transactionId);
 extern bool TransactionIdDidAbort(TransactionId transactionId);
 extern bool TransactionIdIsKnownCompleted(TransactionId transactionId);
 extern void TransactionIdCommitTree(TransactionId xid, int nxids, TransactionId *xids);


### PR DESCRIPTION
The diff generated by github is pretty hard to read because of changes in indentation so I think it is easier to read the original code in heapam_visibility.c first. The changes I made are quite minimal so will be clear if you're familiar with the original code.