### PR TITLE
Add mechanism to identify and handle potential remote deadlocks.

### DIFF
--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -1084,6 +1084,7 @@ ProcSleep(LOCALLOCK *locallock, LockMethod lockMethodTable)
 	bool		early_deadlock = false;
 	bool		allow_autovacuum_cancel = true;
 	bool		logged_recovery_conflict = false;
+	bool 		myProc_is_remotexact = MyProc->isRemoteXact;
 	ProcWaitStatus myWaitStatus;
 	PGPROC	   *proc;
 	PGPROC	   *leader = MyProc->lockGroupLeader;
@@ -1162,6 +1163,17 @@ ProcSleep(LOCALLOCK *locallock, LockMethod lockMethodTable)
 					 * can't do that until we are *on* the wait queue. So, set
 					 * a flag to check below, and break out of loop.  Also,
 					 * record deadlock info for later message.
+					 */
+					RememberSimpleDeadLock(MyProc, lockmode, lock, proc);
+					early_deadlock = true;
+					break;
+				} else if (myProc_is_remotexact && proc->isRemoteXact) {
+					/* 
+					 * Remotexact 
+					 * The MyProc is executing a remotexact and waiting for
+					 * another process that is also executing a remotexact. So
+					 * set the early_deadlock flag to true and break out of the
+					 * loop. Also record the deadlock info for later message. 
 					 */
 					RememberSimpleDeadLock(MyProc, lockmode, lock, proc);
 					early_deadlock = true;


### PR DESCRIPTION
This PR handles the case of potential deadlocks among concurrent remotexacts. It handles two cases:

1. A simple case wherein we can identify the deadlock when acquiring the lock because both transactions involved are remote. 
2. The case where a process is added to a queue and one of the processes in the chain upgrades to a remotexact. In this case, we check for any remotexacts in the process chain while executing DeadLockCheck().
