### PR TITLE
Change HeapTupleSatisfiesMVCC directly

### DIFF
--- a/src/backend/access/transam/remotexact.c
+++ b/src/backend/access/transam/remotexact.c
@@ -31,27 +31,21 @@ SetRemoteXactHook(const RemoteXactHook *hook)
 }
 
 void
-CollectRegion(Relation relation)
+CollectRelation(int region, Oid dbid, Oid relid)
 {
-	CallHook(collect_region)(relation);
+	CallHook(collect_relation)(region, dbid, relid);
 }
 
 void
-CollectRelation(Oid dbid, Oid relid)
+CollectPage(int region, Oid dbid, Oid relid, BlockNumber blkno)
 {
-	CallHook(collect_relation)(dbid, relid);
+	CallHook(collect_page)(region, dbid, relid, blkno);
 }
 
 void
-CollectPage(Oid dbid, Oid relid, BlockNumber blkno)
+CollectTuple(int region, Oid dbid, Oid relid, BlockNumber blkno, OffsetNumber offset)
 {
-	CallHook(collect_page)(dbid, relid, blkno);
-}
-
-void
-CollectTuple(Oid dbid, Oid relid, BlockNumber blkno, OffsetNumber offset)
-{
-	CallHook(collect_tuple)(dbid, relid, blkno, offset);
+	CallHook(collect_tuple)(region, dbid, relid, blkno, offset);
 }
 
 void

--- a/src/backend/access/transam/remotexact.c
+++ b/src/backend/access/transam/remotexact.c
@@ -15,6 +15,7 @@
 int			current_region;
 
 get_region_lsn_hook_type get_region_lsn_hook = NULL;
+get_all_region_lsns_hook_type get_all_region_lsns_hook = NULL;
 
 bool		is_surrogate = false;
 

--- a/src/backend/storage/buffer/localbuf.c
+++ b/src/backend/storage/buffer/localbuf.c
@@ -203,15 +203,17 @@ LocalBufferAlloc(SMgrRelation smgr, ForkNumber forkNum, BlockNumber blockNum,
 					*foundPtr = false;
 
 					ereport(DEBUG1, errmsg("Found non-usable buffer %d for (%d, %d, %d). "
-										   "page_lsn = %ld. region_lsn = %ld. my lxid = %d. lxid = %d",
+										   "page_lsn = %X/%X. region_lsn = %X/%X. my lxid = %d. lxid = %d",
 										   b, smgr->smgr_rnode.node.relNode, forkNum, blockNum,
-										   page_lsn, region_lsn, MyProc->lxid, hresult->lxid));
+										   LSN_FORMAT_ARGS(page_lsn), LSN_FORMAT_ARGS(region_lsn),
+										   MyProc->lxid, hresult->lxid));
 				}
 				else
 					ereport(DEBUG1, errmsg("Found usable buffer %d for (%d, %d, %d). "
-										   "page_lsn = %ld. region_lsn = %ld. my lxid = %d. lxid = %d",
+										   "page_lsn = %X/%X. region_lsn = %X/%X. my lxid = %d. lxid = %d",
 										   b, smgr->smgr_rnode.node.relNode, forkNum, blockNum,
-										   page_lsn, region_lsn, MyProc->lxid, hresult->lxid));
+										   LSN_FORMAT_ARGS(page_lsn), LSN_FORMAT_ARGS(region_lsn),
+										   MyProc->lxid, hresult->lxid));
 			}	
 		}
 		else

--- a/src/backend/storage/lmgr/predicate.c
+++ b/src/backend/storage/lmgr/predicate.c
@@ -461,7 +461,7 @@ static void RemoveTargetIfNoLongerUsed(PREDICATELOCKTARGET *target,
 									   uint32 targettaghash);
 static void DeleteChildTargetLocks(const PREDICATELOCKTARGETTAG *newtargettag);
 static int	MaxPredicateChildLocks(const PREDICATELOCKTARGETTAG *tag);
-static bool CheckAndPromotePredicateLockRequest(const PREDICATELOCKTARGETTAG *reqtag);
+static bool CheckAndPromotePredicateLockRequest(int region, const PREDICATELOCKTARGETTAG *reqtag);
 static void DecrementParentLocks(const PREDICATELOCKTARGETTAG *targettag);
 static void CreatePredicateLock(const PREDICATELOCKTARGETTAG *targettag,
 								uint32 targettaghash,
@@ -470,7 +470,7 @@ static void DeleteLockTarget(PREDICATELOCKTARGET *target, uint32 targettaghash);
 static bool TransferPredicateLocksToNewTarget(PREDICATELOCKTARGETTAG oldtargettag,
 											  PREDICATELOCKTARGETTAG newtargettag,
 											  bool removeOld);
-static void PredicateLockAcquire(const PREDICATELOCKTARGETTAG *targettag);
+static void PredicateLockAcquire(int region, const PREDICATELOCKTARGETTAG *targettag);
 static void DropAllPredicateLocksFromTable(Relation relation,
 										   bool transfer);
 static void SetNewSxactGlobalXmin(void);
@@ -2318,7 +2318,7 @@ MaxPredicateChildLocks(const PREDICATELOCKTARGETTAG *tag)
  * Returns true if a parent lock was acquired and false otherwise.
  */
 static bool
-CheckAndPromotePredicateLockRequest(const PREDICATELOCKTARGETTAG *reqtag)
+CheckAndPromotePredicateLockRequest(int region, const PREDICATELOCKTARGETTAG *reqtag)
 {
 	PREDICATELOCKTARGETTAG targettag,
 				nexttag,
@@ -2364,7 +2364,7 @@ CheckAndPromotePredicateLockRequest(const PREDICATELOCKTARGETTAG *reqtag)
 	if (promote)
 	{
 		/* acquire coarsest ancestor eligible for promotion */
-		PredicateLockAcquire(&promotiontag);
+		PredicateLockAcquire(region, &promotiontag);
 		return true;
 	}
 	else
@@ -2510,7 +2510,7 @@ CreatePredicateLock(const PREDICATELOCKTARGETTAG *targettag,
  * any finer-grained locks covered by the new one.
  */
 static void
-PredicateLockAcquire(const PREDICATELOCKTARGETTAG *targettag)
+PredicateLockAcquire(int region, const PREDICATELOCKTARGETTAG *targettag)
 {
 	uint32		targettaghash;
 	bool		found;
@@ -2543,7 +2543,7 @@ PredicateLockAcquire(const PREDICATELOCKTARGETTAG *targettag)
 	 * coarser granularity, or whether there are finer-granularity locks to
 	 * clean up.
 	 */
-	if (CheckAndPromotePredicateLockRequest(targettag))
+	if (CheckAndPromotePredicateLockRequest(region, targettag))
 	{
 		/*
 		 * Lock request was promoted to a coarser-granularity lock, and that
@@ -2559,6 +2559,8 @@ PredicateLockAcquire(const PREDICATELOCKTARGETTAG *targettag)
 	}
 
 	/*
+	 * Remotexact
+	 *
 	 * Collect the read set of the current transaction.
 	 *
 	 * TODO (ctring): Make use of the promoting mechanism above to reduce the
@@ -2567,18 +2569,21 @@ PredicateLockAcquire(const PREDICATELOCKTARGETTAG *targettag)
 	switch (GET_PREDICATELOCKTARGETTAG_TYPE(*targettag))
 	{
 		case PREDLOCKTAG_RELATION:
-			CollectRelation(GET_PREDICATELOCKTARGETTAG_DB(*targettag),
+			CollectRelation(region,
+							GET_PREDICATELOCKTARGETTAG_DB(*targettag),
 							GET_PREDICATELOCKTARGETTAG_RELATION(*targettag));
 			break;
 
 		case PREDLOCKTAG_PAGE:
-			CollectPage(GET_PREDICATELOCKTARGETTAG_DB(*targettag),
+			CollectPage(region,
+						GET_PREDICATELOCKTARGETTAG_DB(*targettag),
 						GET_PREDICATELOCKTARGETTAG_RELATION(*targettag),
 						GET_PREDICATELOCKTARGETTAG_PAGE(*targettag));
 			break;
 
 		case PREDLOCKTAG_TUPLE:
-			CollectTuple(GET_PREDICATELOCKTARGETTAG_DB(*targettag),
+			CollectTuple(region,
+						 GET_PREDICATELOCKTARGETTAG_DB(*targettag),
 						 GET_PREDICATELOCKTARGETTAG_RELATION(*targettag),
 						 GET_PREDICATELOCKTARGETTAG_PAGE(*targettag),
 						 GET_PREDICATELOCKTARGETTAG_OFFSET(*targettag));
@@ -2606,8 +2611,7 @@ PredicateLockRelation(Relation relation, Snapshot snapshot)
 	SET_PREDICATELOCKTARGETTAG_RELATION(tag,
 										relation->rd_node.dbNode,
 										relation->rd_id);
-	PredicateLockAcquire(&tag);
-	CollectRegion(relation);
+	PredicateLockAcquire(RelationGetRegion(relation), &tag);
 }
 
 /*
@@ -2631,8 +2635,7 @@ PredicateLockPage(Relation relation, BlockNumber blkno, Snapshot snapshot)
 									relation->rd_node.dbNode,
 									relation->rd_id,
 									blkno);
-	PredicateLockAcquire(&tag);
-	CollectRegion(relation);
+	PredicateLockAcquire(RelationGetRegion(relation), &tag);
 }
 
 /*
@@ -2678,8 +2681,7 @@ PredicateLockTID(Relation relation, ItemPointer tid, Snapshot snapshot,
 									 relation->rd_id,
 									 ItemPointerGetBlockNumber(tid),
 									 ItemPointerGetOffsetNumber(tid));
-	PredicateLockAcquire(&tag);
-	CollectRegion(relation);
+	PredicateLockAcquire(RelationGetRegion(relation), &tag);
 }
 
 

--- a/src/include/access/remotexact.h
+++ b/src/include/access/remotexact.h
@@ -39,8 +39,11 @@ extern int current_region;
 
 typedef XLogRecPtr (*get_region_lsn_hook_type) (int region);
 extern PGDLLIMPORT get_region_lsn_hook_type get_region_lsn_hook;
+typedef XLogRecPtr *(*get_all_region_lsns_hook_type) (void);
+extern PGDLLIMPORT get_all_region_lsns_hook_type get_all_region_lsns_hook;
 
 #define GetRegionLsn(r) (get_region_lsn_hook == NULL ? InvalidXLogRecPtr : (*get_region_lsn_hook)(r))
+#define GetAllRegionLsns() (get_all_region_lsns_hook == NULL ? NULL : (*get_all_region_lsns_hook)())
 
 typedef struct
 {

--- a/src/include/access/remotexact.h
+++ b/src/include/access/remotexact.h
@@ -44,10 +44,9 @@ extern PGDLLIMPORT get_region_lsn_hook_type get_region_lsn_hook;
 
 typedef struct
 {
-	void		(*collect_region) (Relation relation);
-	void		(*collect_relation) (Oid dbid, Oid relid);
-	void		(*collect_page) (Oid dbid, Oid relid, BlockNumber blkno);
-	void		(*collect_tuple) (Oid dbid, Oid relid, BlockNumber blkno, OffsetNumber offset);
+	void		(*collect_relation) (int region, Oid dbid, Oid relid);
+	void		(*collect_page) (int region, Oid dbid, Oid relid, BlockNumber blkno);
+	void		(*collect_tuple) (int region, Oid dbid, Oid relid, BlockNumber blkno, OffsetNumber offset);
 	void		(*collect_insert) (Relation relation, HeapTuple newtuple);
 	void		(*collect_update) (Relation relation, HeapTuple oldtuple, HeapTuple newtuple);
 	void		(*collect_delete) (Relation relation, HeapTuple oldtuple);
@@ -56,10 +55,9 @@ typedef struct
 
 extern void SetRemoteXactHook(const RemoteXactHook *hook);
 
-extern void CollectRegion(Relation relation);
-extern void CollectRelation(Oid dbid, Oid relid);
-extern void CollectPage(Oid dbid, Oid relid, BlockNumber blkno);
-extern void CollectTuple(Oid dbid, Oid relid, BlockNumber blkno, OffsetNumber offset);
+extern void CollectRelation(int region, Oid dbid, Oid relid);
+extern void CollectPage(int region, Oid dbid, Oid relid, BlockNumber blkno);
+extern void CollectTuple(int region, Oid dbid, Oid relid, BlockNumber blkno, OffsetNumber offset);
 extern void CollectInsert(Relation relation, HeapTuple newtuple);
 extern void CollectUpdate(Relation relation, HeapTuple oldtuple, HeapTuple newtuple);
 extern void CollectDelete(Relation relation, HeapTuple oldtuple);


### PR DESCRIPTION
Previously, I made a `RemoteHeapTupleSatisfiesMVCC` for `HeapTupleSatisfiesMVCC`, but we're going to do the same for `HeapTupleSatisfiesSelf` and `HeapTupleSatisfiesDirty`, so it would be cleaner if we change the `HeapTuple*` functions directly instead of creating a `RemoteHeapTuple*` variant for each of them. 

This PR removes `RemoteHeapTupleSatisfiesMVCC` and makes the change directly to `HeapTupleSatisfiesMVCC`