### PR TITLE
Replace GLOBAL_REGION with CURRENT_REGION_ALIAS

### DIFF
--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -628,7 +628,7 @@ heapam_relation_copy_data(Relation rel, const RelFileNode *newrnode)
 {
 	SMgrRelation dstrel;
 
-	dstrel = smgropen(*newrnode, rel->rd_backend, rel->rd_rel->relpersistence, rel->rd_rel->relregion);
+	dstrel = smgropen(*newrnode, rel->rd_backend, rel->rd_rel->relpersistence, RelationGetRegion(rel));
 	RelationOpenSmgr(rel);
 
 	/*

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14143,7 +14143,7 @@ index_copy_data(Relation rel, RelFileNode newrnode)
 {
 	SMgrRelation dstrel;
 
-	dstrel = smgropen(newrnode, rel->rd_backend, rel->rd_rel->relpersistence, rel->rd_rel->relregion);
+	dstrel = smgropen(newrnode, rel->rd_backend, rel->rd_rel->relpersistence, RelationGetRegion(rel));
 	RelationOpenSmgr(rel);
 
 	/*

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -317,7 +317,7 @@ pg_relation_size(PG_FUNCTION_ARGS)
 	size = calculate_relation_size(&(rel->rd_node), rel->rd_backend,
 								   forkname_to_number(text_to_cstring(forkName)),
 								   rel->rd_rel->relpersistence,
-								   rel->rd_rel->relregion);
+								   RelationGetRegion(rel));
 
 	relation_close(rel, AccessShareLock);
 
@@ -344,7 +344,7 @@ calculate_toast_table_size(Oid toastrelid)
 		size += calculate_relation_size(&(toastRel->rd_node),
 										toastRel->rd_backend, forkNum,
 										toastRel->rd_rel->relpersistence,
-										toastRel->rd_rel->relregion);
+										RelationGetRegion(toastRel));
 
 	/* toast index size, including FSM and VM size */
 	indexlist = RelationGetIndexList(toastRel);
@@ -360,7 +360,7 @@ calculate_toast_table_size(Oid toastrelid)
 			size += calculate_relation_size(&(toastIdxRel->rd_node),
 											toastIdxRel->rd_backend, forkNum,
 											toastIdxRel->rd_rel->relpersistence,
-											toastIdxRel->rd_rel->relregion);
+											RelationGetRegion(toastIdxRel));
 
 		relation_close(toastIdxRel, AccessShareLock);
 	}
@@ -391,7 +391,7 @@ calculate_table_size(Relation rel)
 		size += calculate_relation_size(&(rel->rd_node), rel->rd_backend,
 										forkNum,
 										rel->rd_rel->relpersistence,
-										rel->rd_rel->relregion);
+										RelationGetRegion(rel));
 
 	/*
 	 * Size of toast relation
@@ -433,7 +433,7 @@ calculate_indexes_size(Relation rel)
 												idxRel->rd_backend,
 												forkNum,
 												idxRel->rd_rel->relpersistence,
-												idxRel->rd_rel->relregion);
+												RelationGetRegion(idxRel));
 
 			relation_close(idxRel, AccessShareLock);
 		}

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -2012,8 +2012,8 @@ formrdesc(const char *relationName, Oid relationReltype,
 		relation->rd_rel->relhasindex = true;
 	}
 
-	/* It is in the global region */
-	relation->rd_rel->relregion = GLOBAL_REGION;
+	/* Set current region alias so that it is resolved to the current region later */
+	relation->rd_rel->relregion = CURRENT_REGION_ALIAS;
 
 	/*
 	 * add new reldesc to relcache
@@ -3635,7 +3635,7 @@ RelationBuildLocalRelation(const char *relname,
 
 	rel->rd_rel->relam = accessmtd;
 
-	rel->rd_rel->relregion = GLOBAL_REGION;
+	rel->rd_rel->relregion = CURRENT_REGION_ALIAS;
 
 	/*
 	 * RelationInitTableAccessMethod will do syscache lookups, so we mustn't

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3649,7 +3649,7 @@ static struct config_int ConfigureNamesInt[] =
 			NULL
 		},
 		&current_region,
-		GLOBAL_REGION, 0, INT_MAX,
+		CURRENT_REGION_ALIAS, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/access/remotexact.h
+++ b/src/include/access/remotexact.h
@@ -15,18 +15,19 @@
 #include "storage/itemptr.h"
 
 #define UNKNOWN_REGION -1
-#define GLOBAL_REGION 0
-#define MAX_REGIONS 64 // 0 reserved for GLOBAL_REGION and 1..63 for user regions.
+#define CURRENT_REGION_ALIAS 0
+#define MAX_REGIONS 64	// 0 reserved for CURRENT_REGION_ALIAS and 1..63 for actual regions.
 
-#define IsMultiRegion() (current_region != GLOBAL_REGION)
-#define RegionIsValid(r) (r != UNKNOWN_REGION)
-#define RegionIsRemote(r) (RegionIsValid(r) && r != current_region && r != GLOBAL_REGION)
+#define IsMultiRegion() (current_region != CURRENT_REGION_ALIAS)
+#define RegionIsValid(r) (r > CURRENT_REGION_ALIAS)
+#define RegionIsRemote(r) (RegionIsValid(r) && r != current_region)
+#define ResolveRegion(region) (region == CURRENT_REGION_ALIAS ? current_region : region)
 
 /*
  * RelationGetRegion
  *		Fetch relation's region.
  */
-#define RelationGetRegion(relation) ((relation)->rd_rel->relregion)
+#define RelationGetRegion(relation) (ResolveRegion((relation)->rd_rel->relregion))
 
 /*
  * RelationIsRemote

--- a/src/include/catalog/pg_class.h
+++ b/src/include/catalog/pg_class.h
@@ -122,8 +122,8 @@ CATALOG(pg_class,1259,RelationRelationId) BKI_BOOTSTRAP BKI_ROWTYPE_OID(83,Relat
 	/* link to original rel during table rewrite; otherwise 0 */
 	Oid			relrewrite BKI_DEFAULT(0) BKI_LOOKUP_OPT(pg_class);
 
-	/* region that the relation belongs to; 0 means it is in the global region */
-	int32		relregion BKI_DEFAULT(0);
+	/* region that the relation belongs to; 0 means it will be resolved to the current region */
+	int16		relregion BKI_DEFAULT(0);
 
 	/* all Xids < this are frozen in this rel */
 	TransactionId relfrozenxid BKI_DEFAULT(3);	/* FirstNormalTransactionId */

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -536,7 +536,7 @@ typedef struct ViewOptions
 		if ((relation)->rd_smgr == NULL) \
 			smgrsetowner(&((relation)->rd_smgr), \
 						 smgropen((relation)->rd_node, (relation)->rd_backend, \
-						 		  (relation)->rd_rel->relpersistence, (relation)->rd_rel->relregion)); \
+						 		  (relation)->rd_rel->relpersistence, RelationGetRegion(relation))); \
 	} while (0)
 
 /*


### PR DESCRIPTION
The default region of a relation and catalog is set to GLOBAL_REGION, this means no region can make change to the catalog. However, it makes more sense if we let each region modifies the catalogs as needed as long as all regions agree on the schemas (we assume schemas do not change for now). Things like statistics tables or the some physical data in a catalog page (e.g. deleted tuples) can diverge. 

The GLOBAL_REGION concept actually causes a bug in vacuuming and crashes the database (I'm not exactly sure about the details but vacuum fetched a page multiple times during its run but since its changes were not registered, the re-fetch after the change resulted in the unmodified version of the page and caused inconsistency). 

I'm replacing GLOBAL_REGION with CURRENT_REGION_ALIAS, which is still set to 0 but the semantic is that the region of the relation is translated to `current_region` if the region of the relation in `pg_class` is CURRENT_REGION_ALIAS. This change fixed the bug mentioned above.