### PR TITLE
Implement the heap_only_get_page function

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -502,13 +502,6 @@ heapgetpage(TableScanDesc sscan, BlockNumber page)
 
 void heap_only_get_page(HeapScanDesc scan, BlockNumber page) {
 	Buffer		buffer;
-	Snapshot	snapshot;
-	Page		dp;
-	int			lines;
-	int			ntup;
-	OffsetNumber lineoff;
-	ItemId		lpp;
-	bool		all_visible;
 
 	Assert(page < scan->rs_nblocks);
 

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -500,9 +500,8 @@ heapgetpage(TableScanDesc sscan, BlockNumber page)
 	scan->rs_ntuples = ntup;
 }
 
-void heap_only_get_page(HeapScanDesc scan, BlockNumber page) {
-	Buffer		buffer;
-
+void heap_getpageonly(HeapScanDesc scan, BlockNumber page)
+{
 	Assert(page < scan->rs_nblocks);
 
 	/* release previous scan buffer, if any */

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -500,6 +500,43 @@ heapgetpage(TableScanDesc sscan, BlockNumber page)
 	scan->rs_ntuples = ntup;
 }
 
+void heap_only_get_page(HeapScanDesc scan, BlockNumber page) {
+	Buffer		buffer;
+	Snapshot	snapshot;
+	Page		dp;
+	int			lines;
+	int			ntup;
+	OffsetNumber lineoff;
+	ItemId		lpp;
+	bool		all_visible;
+
+	Assert(page < scan->rs_nblocks);
+
+	/* release previous scan buffer, if any */
+	if (BufferIsValid(scan->rs_cbuf))
+	{
+		ReleaseBuffer(scan->rs_cbuf);
+		scan->rs_cbuf = InvalidBuffer;
+	}
+
+
+	/*
+	 * Be sure to check for interrupts at least once per page.  Checks at
+	 * higher code levels won't be able to stop a seqscan that encounters many
+	 * pages' worth of consecutive dead tuples.
+	 */
+	CHECK_FOR_INTERRUPTS();
+
+	/* We only fetch the required page and don't prefetch any subsequent pages 
+	 * because the validation requests will not be sequential. 
+	 * Read page using the default strategy.
+	 */
+	scan->rs_cbuf = ReadBufferExtended(scan->rs_base.rs_rd, MAIN_FORKNUM, page,
+									   RBM_NORMAL, scan->rs_strategy);
+	scan->rs_cblock = page;
+	return;
+}
+
 /* ----------------
  *		heapgettup - fetch next heap tuple
  *

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -121,6 +121,7 @@ extern TableScanDesc heap_beginscan(Relation relation, Snapshot snapshot,
 extern void heap_setscanlimits(TableScanDesc scan, BlockNumber startBlk,
 							   BlockNumber numBlks);
 extern void heapgetpage(TableScanDesc scan, BlockNumber page);
+extern void heap_only_get_page(HeapScanDesc scan, BlockNumber page);
 extern void heap_rescan(TableScanDesc scan, ScanKey key, bool set_params,
 						bool allow_strat, bool allow_sync, bool allow_pagemode);
 extern void heap_endscan(TableScanDesc scan);

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -121,7 +121,7 @@ extern TableScanDesc heap_beginscan(Relation relation, Snapshot snapshot,
 extern void heap_setscanlimits(TableScanDesc scan, BlockNumber startBlk,
 							   BlockNumber numBlks);
 extern void heapgetpage(TableScanDesc scan, BlockNumber page);
-extern void heap_only_get_page(HeapScanDesc scan, BlockNumber page);
+extern void heap_getpageonly(HeapScanDesc scan, BlockNumber page);
 extern void heap_rescan(TableScanDesc scan, ScanKey key, bool set_params,
 						bool allow_strat, bool allow_sync, bool allow_pagemode);
 extern void heap_endscan(TableScanDesc scan);


### PR DESCRIPTION
Implements an additional heap scan function to help with index validation. 

The heap_only_get_page fetches the required page from memory without any visibility checked. The regular heap_get_page function also does a page-level visibility check of the tuples and reclaims any space on the page. It also does prefetching. We don't need any of that because we can't interpret the visibility of entries without knowing the exact index implementation. Additionally, prefetching won't help us during validation because the index pages would go from root -> leaves and may not be sequential.  

I have tested this function with the validation code and it works as expected. 