### PR TITLE
Fix dropping remote page in local buf bug

### DIFF
--- a/src/backend/storage/buffer/localbuf.c
+++ b/src/backend/storage/buffer/localbuf.c
@@ -314,8 +314,8 @@ LocalBufferAlloc(SMgrRelation smgr, ForkNumber forkNum, BlockNumber blockNum,
 		/*
 		 * Remotexact
 		 * We only writes to disk pages that do not belong to remote relations.
-		 * The remote pages here must belong to a previous transaction due to
-		 * the check above so it is safe to simply discard them.
+		 * If the buffer contains a remote page here, it must belong to a previous
+		 * transaction due to the check above so it is safe to simply discard the page.
 		 */
 		if (!remote_bufHdr->is_remote)
 		{


### PR DESCRIPTION
When the local buffer pool is full, a page needs to be evicted from the buffer pool. This page will be written back to disk, this happens in the if block on line 286. 

We don't want/need to write a page of the remote relations to disk but the write back code initializes an smgr object that would write the page to disk anyway since it assumes all pages in the local buf to belong to temporary relations.

This PR changes that by storing extra metadata of local buffers in an array of `RemoteBufferDesc`s called `LocalBufferRemoteDescriptors`. Each `RemoteBufferDesc` can be seen as an extension of the corresponding `BufferDesc` struct in `LocalBufferDescriptors` (We don't want to add more fields in the `BufferDesc` struct because the shared buffer pool also uses this struct).  The `RemoteBufferDesc` store metadata that let us know whether a buffer is storing a page of a remote relation (`is_remote`) and the local transaction id (`lxid`). The local transaction id field was in `LocalBufferLookupEnt` previously but we move it here now to make things more organized.

If the `is_remote` field of a buffer is `true`, we simply discard the page instead of writing it back to disk.