### PR TITLE
Avoid marking page dirty for non-critical changes

### DIFF
--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -1600,7 +1600,7 @@ MarkBufferDirty(Buffer buffer)
 
 	if (BufferIsLocal(buffer))
 	{
-		MarkLocalBufferDirty(buffer, false);
+		MarkLocalBufferDirty(buffer, true);
 		return;
 	}
 
@@ -3917,7 +3917,7 @@ MarkBufferDirtyHint(Buffer buffer, bool buffer_std)
 
 	if (BufferIsLocal(buffer))
 	{
-		MarkLocalBufferDirty(buffer, true);
+		MarkLocalBufferDirty(buffer, false);
 		return;
 	}
 

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -1600,7 +1600,7 @@ MarkBufferDirty(Buffer buffer)
 
 	if (BufferIsLocal(buffer))
 	{
-		MarkLocalBufferDirty(buffer);
+		MarkLocalBufferDirty(buffer, false);
 		return;
 	}
 
@@ -3917,7 +3917,7 @@ MarkBufferDirtyHint(Buffer buffer, bool buffer_std)
 
 	if (BufferIsLocal(buffer))
 	{
-		MarkLocalBufferDirty(buffer);
+		MarkLocalBufferDirty(buffer, true);
 		return;
 	}
 

--- a/src/include/storage/buf_internals.h
+++ b/src/include/storage/buf_internals.h
@@ -338,7 +338,7 @@ extern PrefetchBufferResult PrefetchLocalBuffer(SMgrRelation smgr,
 												BlockNumber blockNum);
 extern BufferDesc *LocalBufferAlloc(SMgrRelation smgr, ForkNumber forkNum,
 									BlockNumber blockNum, bool *foundPtr);
-extern void MarkLocalBufferDirty(Buffer buffer, bool hint);
+extern void MarkLocalBufferDirty(Buffer buffer, bool is_wal_change);
 extern void DropRelFileNodeLocalBuffers(RelFileNode rnode, ForkNumber forkNum,
 										BlockNumber firstDelBlock);
 extern void DropRelFileNodeAllLocalBuffers(RelFileNode rnode);

--- a/src/include/storage/buf_internals.h
+++ b/src/include/storage/buf_internals.h
@@ -338,7 +338,7 @@ extern PrefetchBufferResult PrefetchLocalBuffer(SMgrRelation smgr,
 												BlockNumber blockNum);
 extern BufferDesc *LocalBufferAlloc(SMgrRelation smgr, ForkNumber forkNum,
 									BlockNumber blockNum, bool *foundPtr);
-extern void MarkLocalBufferDirty(Buffer buffer);
+extern void MarkLocalBufferDirty(Buffer buffer, bool hint);
 extern void DropRelFileNodeLocalBuffers(RelFileNode rnode, ForkNumber forkNum,
 										BlockNumber firstDelBlock);
 extern void DropRelFileNodeAllLocalBuffers(RelFileNode rnode);


### PR DESCRIPTION
Tested with read-only query reading remote data using a small local buffer. 