### PR TITLE
Fix out-of-bound access bug in local buffer

### DIFF
--- a/src/backend/storage/buffer/localbuf.c
+++ b/src/backend/storage/buffer/localbuf.c
@@ -581,7 +581,7 @@ InitLocalBuffers(void)
 	for (i = 0; i < nbufs; i++)
 	{
 		BufferDesc *buf = GetLocalBufferDescriptor(i);
-		RemoteBufferDesc *rbuf = LocalBufHdrGetRemoteDesc(buf);
+		RemoteBufferDesc *rbuf = &LocalBufferRemoteDescriptors[i]; /* Remotexact */
 
 		/*
 		 * negative to indicate local buffer. This is tricky: shared buffers


### PR DESCRIPTION
The `LocalBufHdrGetRemoteDesc` macro uses `buf->buf_id` to select the remote descriptor, however this field is not initialized at this point yet. There is no need to use that macro here anyway so just use `i` directly. 