### PR TITLE
Avoid heap pruning on remote relations

### DIFF
--- a/src/backend/access/heap/pruneheap.c
+++ b/src/backend/access/heap/pruneheap.c
@@ -121,6 +121,13 @@ heap_page_prune_opt(Relation relation, Buffer buffer)
 		return;
 
 	/*
+	 * Remotexact
+	 * Never prune remote relations
+	 */
+	if (RelationIsRemote(relation))
+		return;
+
+	/*
 	 * XXX: Magic to keep old_snapshot_threshold tests appear "working". They
 	 * currently are broken, and discussion of what to do about them is
 	 * ongoing. See

--- a/src/backend/storage/buffer/localbuf.c
+++ b/src/backend/storage/buffer/localbuf.c
@@ -215,17 +215,19 @@ LocalBufferAlloc(SMgrRelation smgr, ForkNumber forkNum, BlockNumber blockNum,
 					*foundPtr = false;
 
 					ereport(DEBUG1, errmsg("Found non-usable buffer %d for (%d, %d, %d). "
-										   "page_lsn = %X/%X. region_lsn = %X/%X. my lxid = %d. lxid = %d",
+										   "region = %d. dirty = %u. page_lsn = %X/%X. "
+										   "region_lsn = %X/%X. my_lxid = %u. lxid = %u",
 										   b, smgr->smgr_rnode.node.relNode, forkNum, blockNum,
-										   LSN_FORMAT_ARGS(page_lsn), LSN_FORMAT_ARGS(region_lsn),
-										   MyProc->lxid, remote_bufHdr->lxid));
+										   smgr->smgr_region, (buf_state & BM_DIRTY) > 0, LSN_FORMAT_ARGS(page_lsn),
+										   LSN_FORMAT_ARGS(region_lsn), MyProc->lxid, remote_bufHdr->lxid));
 				}
 				else
 					ereport(DEBUG1, errmsg("Found usable buffer %d for (%d, %d, %d). "
-										   "page_lsn = %X/%X. region_lsn = %X/%X. my lxid = %d. lxid = %d",
+										   "region = %d. dirty = %u. page_lsn = %X/%X. "
+										   "region_lsn = %X/%X. my_lxid = %u. lxid = %u",
 										   b, smgr->smgr_rnode.node.relNode, forkNum, blockNum,
-										   LSN_FORMAT_ARGS(page_lsn), LSN_FORMAT_ARGS(region_lsn),
-										   MyProc->lxid, remote_bufHdr->lxid));
+										   smgr->smgr_region, (buf_state & BM_DIRTY) > 0, LSN_FORMAT_ARGS(page_lsn),
+										   LSN_FORMAT_ARGS(region_lsn), MyProc->lxid, remote_bufHdr->lxid));
 			}	
 		}
 		else


### PR DESCRIPTION
Heap pruning is an opportunistic mechanism to quickly garbage collect the page during a query and it messes up the remote pages.

`CSNSnapshotAbort` makes request to the page server which would fail in a critical section. 