### PR TITLE
Fix wrong buffer returned bug in heap_lock_tuple

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -4511,14 +4511,17 @@ heap_lock_tuple(Relation relation, HeapTuple tuple,
 	bool		have_tuple_lock = false;
 	bool		cleared_all_frozen = false;
 
+	*buffer = ReadBuffer(relation, ItemPointerGetBlockNumber(tid));
+
 	/*
 	 * Remotexact
-	 * Locking is a no-op for remote relations because they are in local buffer
+	 * Locking is a no-op for remote relations because they are in local buffer.
+	 * This check must happen after the assignment of the "buffer" variable above
+	 * so that a correct buffer is returned.
 	 */
 	if (RelationIsRemote(relation))
 		return TM_Ok;
 
-	*buffer = ReadBuffer(relation, ItemPointerGetBlockNumber(tid));
 	block = ItemPointerGetBlockNumber(tid);
 
 	/*


### PR DESCRIPTION
Got an error where postgres complained about invalid buffer. While we want to skip this function on remote relation, we still need the function to return the correct buffer because the caller depends on it. 