### PR TITLE
Fix wrong buffer returned bug in heap_lock_tuple

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -4593,14 +4593,17 @@ heap_lock_tuple(Relation relation, HeapTuple tuple,
 	bool		have_tuple_lock = false;
 	bool		cleared_all_frozen = false;
 
+	*buffer = ReadBuffer(relation, ItemPointerGetBlockNumber(tid));
+
 	/*
 	 * Remotexact
-	 * Locking is a no-op for remote relations because they are in local buffer
+	 * Locking is a no-op for remote relations because they are in local buffer.
+	 * This check must happen after the assignment of the "buffer" variable above
+	 * so that a correct buffer is returned.
 	 */
 	if (RelationIsRemote(relation))
 		return TM_Ok;
 
-	*buffer = ReadBuffer(relation, ItemPointerGetBlockNumber(tid));
 	block = ItemPointerGetBlockNumber(tid);
 
 	/*

--- a/src/include/access/slru.h
+++ b/src/include/access/slru.h
@@ -140,10 +140,10 @@ typedef struct SlruCtlData
 
 typedef SlruCtlData *SlruCtl;
 
-typedef bool (*slru_kind_check_hook_type) (SlruCtl ctl);
+typedef bool (*slru_is_remote_page_hook_type) (SlruCtl ctl, BlockNumber blkno);
 typedef bool (*slru_page_exists_hook_type) (SlruCtl ctl, int segno, BlockNumber blkno);
 typedef bool (*slru_read_page_hook_type) (SlruCtl ctl, int segno, BlockNumber blkno, XLogRecPtr min_lsn, char *buffer);
-extern PGDLLIMPORT slru_kind_check_hook_type slru_kind_check_hook;
+extern PGDLLIMPORT slru_is_remote_page_hook_type slru_is_remote_page_hook;
 extern PGDLLIMPORT slru_page_exists_hook_type slru_page_exists_hook;
 extern PGDLLIMPORT slru_read_page_hook_type slru_read_page_hook;
 


### PR DESCRIPTION
Got an error where postgres complained about invalid buffer. While we want to skip this function on remote relation, we still need the function to return the correct buffer because the caller depends on it. 