### PR TITLE
[v14] Make sure xids of remote tuples are used safely (1/n)

### DIFF
--- a/src/backend/catalog/pg_inherits.c
+++ b/src/backend/catalog/pg_inherits.c
@@ -146,6 +146,12 @@ find_inheritance_children_extended(Oid parentrelId, bool omit_detached,
 				TransactionId xmin;
 				Snapshot	snap;
 
+				/*
+				 * Remotexact (xid)
+				 * This code path is reached when there is a concurrent detachment of
+				 * a partition. We assume no DDL happen in concurrent to DML so this
+				 * is fine.
+				 */
 				xmin = HeapTupleHeaderGetXmin(inheritsTuple->t_data);
 				snap = GetActiveSnapshot();
 

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1207,6 +1207,10 @@ read_seq_tuple(Relation rel, Buffer *buf, HeapTuple seqdatatuple)
 	 * see this has happened, clean up after it.  We treat this like a hint
 	 * bit update, ie, don't bother to WAL-log it, since we can certainly do
 	 * this again if the update gets lost.
+	 * 
+	 * Remotexact (xid)
+	 * Reading xmax from a remote relation is safe here because it does not have
+	 * any side effect
 	 */
 	Assert(!(seqdatatuple->t_data->t_infomask & HEAP_XMAX_IS_MULTI));
 	if (HeapTupleHeaderGetRawXmax(seqdatatuple->t_data) != InvalidTransactionId)

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -241,6 +241,10 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 			 * If the index is valid, but cannot yet be used, ignore it; but
 			 * mark the plan we are generating as transient. See
 			 * src/backend/access/heap/README.HOT for discussion.
+			 * 
+			 * Remotexact (xid)
+			 * This is fine as long as the assumption that DDL operations never run concurrently
+			 * with DML operations holds.
 			 */
 			if (index->indcheckxmin &&
 				!TransactionIdPrecedes(HeapTupleHeaderGetXmin(indexRelation->rd_indextuple->t_data),

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -2302,6 +2302,10 @@ RelationReloadIndexInfo(Relation relation)
 		relation->rd_index->indislive = index->indislive;
 
 		/* Copy xmin too, as that is needed to make sense of indcheckxmin */
+		/*
+		 * Remotexact (xid)
+		 * This is xid-safe because it does not have any side effect
+		 */
 		HeapTupleHeaderSetXmin(relation->rd_indextuple->t_data,
 							   HeapTupleHeaderGetXmin(tuple->t_data));
 


### PR DESCRIPTION
+ Comments on sites that are confirmed to be safe
+ Some extra checking for pg_enum 