### PR TITLE
[v14] Make sure xids of remote tuples are used safely (2/n)

### DIFF
--- a/src/backend/access/heap/pruneheap.c
+++ b/src/backend/access/heap/pruneheap.c
@@ -578,6 +578,10 @@ heap_prune_satisfies_vacuum(PruneState *prstate, HeapTuple tup, Buffer buffer)
  * state are added to nowunused[].
  *
  * Returns the number of tuples (to be) deleted from the page.
+ * 
+ * Remotexact (xid)
+ * This function is xid-safe because it is called by heap_page_prune_opt, which
+ * immediately returns when the relation is remote.
  */
 static int
 heap_prune_chain(Buffer buffer, OffsetNumber rootoffnum, PruneState *prstate)

--- a/src/backend/access/heap/rewriteheap.c
+++ b/src/backend/access/heap/rewriteheap.c
@@ -356,6 +356,10 @@ end_heap_rewrite(RewriteState state)
  * state		opaque state as returned by begin_heap_rewrite
  * old_tuple	original tuple in the old heap
  * new_tuple	new, rewritten tuple to be inserted to new heap
+ * 
+ * Remotexact (xid)
+ * The two code paths that lead to this are cluster and vacuum, which are never
+ * called on a remote relation
  */
 void
 rewrite_heap_tuple(RewriteState state,
@@ -558,6 +562,10 @@ rewrite_heap_tuple(RewriteState state,
  * Returns true if a tuple was removed from the unresolved_tups table.
  * This indicates that that tuple, previously thought to be "recently dead",
  * is now known really dead and won't be written to the output.
+ * 
+ * Remotexact (xid)
+ * The two code paths that lead to this are cluster and vacuum, which are never
+ * called on a remote relation
  */
 bool
 rewrite_heap_dead_tuple(RewriteState state, HeapTuple old_tuple)
@@ -1031,6 +1039,10 @@ logical_rewrite_log_mapping(RewriteState state, TransactionId xid,
 /*
  * Perform logical remapping for a tuple that's mapped from old_tid to
  * new_tuple->t_self by rewrite_heap_tuple() if necessary for the tuple.
+ *
+ * Remotexact (xid)
+ * The two code paths that lead to this are cluster and vacuum, which are never
+ * called on a remote relation
  */
 static void
 logical_rewrite_heap_tuple(RewriteState state, ItemPointerData old_tid,

--- a/src/backend/access/heap/vacuumlazy.c
+++ b/src/backend/access/heap/vacuumlazy.c
@@ -1904,6 +1904,10 @@ retry:
 					/*
 					 * The inserter definitely committed. But is it old enough
 					 * that everyone sees it as committed?
+					 * 
+					 * Remotexact (xid)
+					 * Reading xmin here is safe because this code is only called through vacuum_rel,
+					 * which skips remote relations.
 					 */
 					xmin = HeapTupleHeaderGetXmin(tuple.t_data);
 					if (!TransactionIdPrecedes(xmin, vacrel->OldestXmin))
@@ -3763,6 +3767,10 @@ heap_page_is_all_visible(LVRelState *vacrel, Buffer buf,
 					/*
 					 * The inserter definitely committed. But is it old enough
 					 * that everyone sees it as committed?
+					 * 
+					 * Remotexact (xid)
+					 * Reading xmin here is safe because this code is only called through vacuum_rel,
+					 * which skips remote relations.
 					 */
 					xmin = HeapTupleHeaderGetXmin(tuple.t_data);
 					if (!TransactionIdPrecedes(xmin, vacrel->OldestXmin))

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -178,8 +178,11 @@ analyze_rel(Oid relid, RangeVar *relation,
 	 * trying to analyze these is rather pointless, since their contents are
 	 * probably not up-to-date on disk.  (We don't throw a warning here; it
 	 * would just lead to chatter during a database-wide ANALYZE.)
+	 * 
+	 * Remotexact
+	 * Ignore remote tables
 	 */
-	if (RELATION_IS_OTHER_TEMP(onerel))
+	if (RELATION_IS_OTHER_TEMP(onerel) || RelationIsRemote(onerel))
 	{
 		relation_close(onerel, ShareUpdateExclusiveLock);
 		return;

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -21,6 +21,7 @@
 #include "access/heapam.h"
 #include "access/multixact.h"
 #include "access/relscan.h"
+#include "access/remotexact.h"
 #include "access/tableam.h"
 #include "access/toast_internals.h"
 #include "access/transam.h"
@@ -153,6 +154,12 @@ cluster(ParseState *pstate, ClusterStmt *stmt, bool isTopLevel)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot cluster a partitioned table")));
+
+		/* Remotexact */
+		if (RelationIsRemote(rel))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("cannot cluster a remote table")));
 
 		if (stmt->indexname == NULL)
 		{


### PR DESCRIPTION
+ Add checks in cluster and analyze command to avoid running on remote relations
+ Add comments to confirm xid safety of related functions