### PR TITLE
[v14] Make sure xids of remote tuples are used safely (6/n)

### DIFF
--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -1157,6 +1157,11 @@ heapam_scan_analyze_next_tuple(TableScanDesc scan, TransactionId OldestXmin,
 	return false;
 }
 
+/*
+ * Remotexact (xid)
+ * This function is used for building index on existing data. We do not
+ * support building indexes on remote relations so this function is xid-safe
+ */
 static double
 heapam_index_build_range_scan(Relation heapRelation,
 							  Relation indexRelation,
@@ -1187,6 +1192,12 @@ heapam_index_build_range_scan(Relation heapRelation,
 	BlockNumber previous_blkno = InvalidBlockNumber;
 	BlockNumber root_blkno = InvalidBlockNumber;
 	OffsetNumber root_offsets[MaxHeapTuplesPerPage];
+
+	/* 
+	 * Remotexact
+	 * We do not support building indexes on remote relations
+	 */
+	Assert(!RelationIsRemote(heapRelation));
 
 	/*
 	 * sanity checks
@@ -1732,6 +1743,11 @@ heapam_index_build_range_scan(Relation heapRelation,
 	return reltuples;
 }
 
+/*
+ * Remotexact (xid)
+ * This function is used during index build. We do not support building indexes on
+ * remote relations so this function is xid-safe.
+ */
 static void
 heapam_index_validate_scan(Relation heapRelation,
 						   Relation indexRelation,
@@ -1757,6 +1773,12 @@ heapam_index_validate_scan(Relation heapRelation,
 	ItemPointer indexcursor = NULL;
 	ItemPointerData decoded;
 	bool		tuplesort_empty = false;
+
+	/* 
+	 * Remotexact
+	 * We do not support building indexes on remote relations
+	 */
+	Assert(!RelationIsRemote(heapRelation));
 
 	/*
 	 * sanity checks
@@ -2207,6 +2229,10 @@ heapam_scan_bitmap_next_block(TableScanDesc scan,
 			if (valid)
 			{
 				hscan->rs_vistuples[ntup++] = offnum;
+				/*
+				 * Remotexact (xid)
+				 * This is safe because remote relations are ignore in predicate locking
+				 */
 				PredicateLockTID(scan->rs_rd, &loctup.t_self, snapshot,
 								 HeapTupleHeaderGetXmin(loctup.t_data));
 			}

--- a/src/backend/access/heap/pruneheap.c
+++ b/src/backend/access/heap/pruneheap.c
@@ -959,6 +959,11 @@ heap_page_prune_execute(Buffer buffer,
  * Note: The information collected here is valid only as long as the caller
  * holds a pin on the buffer. Once pin is released, a tuple might be pruned
  * and reused by a completely unrelated tuple.
+ * 
+ * Remotexact (xid)
+ * This function is only called during index build via heapam_index_validate_scan
+ * and heapam_index_build_range_scan, both of which do not run on remote relations
+ * so this function is xid-safe.
  */
 void
 heap_get_root_tuples(Page page, OffsetNumber *root_offsets)


### PR DESCRIPTION
Make sure index build is not run on remote table