### PR TITLE
Disable SSI checks on remote relations

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1838,11 +1838,12 @@ heap_fetch_extended(Relation relation,
 
 	if (valid)
 		/*
-		* Remotexact (xid)
-		* This is safe because remote relations are ignore in predicate locking
-		*/
+		 * Remotexact (xid)
+		 * This is safe because PredicateLockTID can handle the remote relation case.
+		 */
 		PredicateLockTID(relation, &(tuple->t_self), snapshot,
-						 HeapTupleHeaderGetXmin(tuple->t_data));
+						 HeapTupleHeaderGetXmin(tuple->t_data),
+						 HeapTupleHeaderIsXminLocal(tuple->t_data));
 
 	HeapCheckForSerializableConflictOut(valid, relation, tuple, buffer, snapshot);
 
@@ -1995,10 +1996,11 @@ heap_hot_search_buffer(ItemPointer tid, Relation relation, Buffer buffer,
 				ItemPointerSetOffsetNumber(tid, offnum);
 				/*
 				* Remotexact (xid)
-				* This is safe because remote relations are ignore in predicate locking
+				* This is safe because PredicateLockTID can handle the remote relation case.
 				*/
 				PredicateLockTID(relation, &heapTuple->t_self, snapshot,
-								 HeapTupleHeaderGetXmin(heapTuple->t_data));
+								 HeapTupleHeaderGetXmin(heapTuple->t_data),
+								 HeapTupleHeaderIsXminLocal(heapTuple->t_data));
 				if (all_dead)
 					*all_dead = false;
 				return true;

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -2246,10 +2246,11 @@ heapam_scan_bitmap_next_block(TableScanDesc scan,
 				hscan->rs_vistuples[ntup++] = offnum;
 				/*
 				 * Remotexact (xid)
-				 * This is safe because remote relations are ignore in predicate locking
+				 * This is safe because PredicateLockTID can handle the remote relation case.
 				 */
 				PredicateLockTID(scan->rs_rd, &loctup.t_self, snapshot,
-								 HeapTupleHeaderGetXmin(loctup.t_data));
+								 HeapTupleHeaderGetXmin(loctup.t_data),
+								 HeapTupleHeaderIsXminLocal(loctup.t_data));
 			}
 			HeapCheckForSerializableConflictOut(valid, scan->rs_rd, &loctup,
 												buffer, snapshot);

--- a/src/include/storage/predicate.h
+++ b/src/include/storage/predicate.h
@@ -58,7 +58,7 @@ extern void RegisterPredicateLockingXid(TransactionId xid);
 extern void PredicateLockRelation(Relation relation, Snapshot snapshot);
 extern void PredicateLockPage(Relation relation, BlockNumber blkno, Snapshot snapshot);
 extern void PredicateLockTID(Relation relation, ItemPointer tid, Snapshot snapshot,
-							 TransactionId insert_xid);
+							 TransactionId insert_xid, bool is_insert_xid_local);
 extern void PredicateLockPageSplit(Relation relation, BlockNumber oldblkno, BlockNumber newblkno);
 extern void PredicateLockPageCombine(Relation relation, BlockNumber oldblkno, BlockNumber newblkno);
 extern void TransferPredicateLocksToHeapRelation(Relation relation);


### PR DESCRIPTION
+ Add a `allow_remote_relation` argument for `PredicateLockingNeededForRelation` to control whether we want to allow predicate locking on a remote relation or not.
+ We only allow acquiring the locks so that the read set can piggyback on these functions. However, we disallow SSI checking on the remote relations.